### PR TITLE
feat: migrate to monorepo (add infra/ and frontend/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
-# Backend
+# backend (monorepo)
 
-This repository contains backend services.
+Монорепо для auth-service.
+
+## Структура
+
+```
+├── auth/        # Backend: Kotlin/Ktor auth service
+├── frontend/    # Frontend (coming soon)
+└── infra/       # Infrastructure: Helm, Terraform, Docker, Ops
+```
+
+## Быстрый старт
+
+```bash
+# Локальная разработка
+docker-compose -f infra/docker-compose.yaml up
+
+# Deploy
+cd infra/terraform
+terraform init && terraform apply
+```

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,0 +1,30 @@
+FROM gradle:8.14-jdk21 AS builder
+
+WORKDIR /app
+
+COPY gradlew gradlew.bat ./
+COPY gradle/ gradle/
+COPY gradle.properties settings.gradle.kts build.gradle.kts ./
+
+COPY domain/build.gradle.kts domain/
+COPY server/build.gradle.kts server/
+
+RUN gradle dependencies --no-daemon || true
+
+COPY domain/src domain/src
+COPY server/src server/src
+
+RUN gradle :server:buildFatJar --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS runtime
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+USER appuser
+
+WORKDIR /app
+
+COPY --from=builder /app/server/build/libs/*-all.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/infra/docker-compose.yaml
+++ b/infra/docker-compose.yaml
@@ -1,0 +1,146 @@
+services:
+  app:
+    build:
+      context: ../auth
+      dockerfile: ../infra/Dockerfile
+    container_name: auth-service-app
+    restart: unless-stopped
+    expose:
+      - "8080"
+    environment:
+      JWT_SECRET: "change-me-in-production"
+      JWT_ISSUER: "auth-service"
+      JWT_AUDIENCE: "auth-service-users"
+      STORAGE_BACKEND: "dragonfly"
+      DRAGONFLY_HOST: "dragonfly"
+      DRAGONFLY_PORT: "6379"
+    depends_on:
+      dragonfly:
+        condition: service_healthy
+    networks:
+      - observability
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/metrics > /dev/null || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
+
+  nginx:
+    image: nginx:alpine
+    container_name: auth-service-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./ops/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - observability
+
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:1.3.0
+    container_name: auth-service-nginx-exporter
+    restart: unless-stopped
+    command:
+      - --nginx.scrape-uri=http://nginx:8080/stub_status
+    expose:
+      - "9113"
+    depends_on:
+      - nginx
+    networks:
+      - observability
+
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    container_name: auth-service-dragonfly
+    restart: unless-stopped
+    command: dragonfly --logtostderr
+    ports:
+      - "6379:6379"
+    ulimits:
+      memlock: -1
+    networks:
+      - observability
+    healthcheck:
+      test: ["CMD", "redis-cli", "-h", "localhost", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  dragonfly-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: auth-service-dragonfly-exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: "redis://dragonfly:6379"
+    expose:
+      - "9121"
+    depends_on:
+      dragonfly:
+        condition: service_healthy
+    networks:
+      - observability
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: auth-service-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./ops/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    depends_on:
+      - app
+      - cadvisor
+      - dragonfly-exporter
+      - nginx-exporter
+    networks:
+      - observability
+
+  grafana:
+    image: grafana/grafana:11.1.4
+    container_name: auth-service-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./ops/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    networks:
+      - observability
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: auth-service-cadvisor
+    restart: unless-stopped
+    ports:
+      - "8081:8080"
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:rw
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - observability
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+networks:
+  observability:
+    driver: bridge

--- a/infra/helm/auth-service/Chart.yaml
+++ b/infra/helm/auth-service/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: auth-service
+description: Helm chart for auth-service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+
+dependencies:
+  - name: redis
+    version: "19.x.x"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: dragonfly
+    condition: dragonfly.enabled

--- a/infra/helm/auth-service/ip/values-ip.yaml
+++ b/infra/helm/auth-service/ip/values-ip.yaml
@@ -1,0 +1,11 @@
+ingress:
+  enabled: false
+
+service:
+  type: NodePort
+  port: 8080
+  nodePort: 30081
+
+env:
+  STORAGE_IN_MEMORY: "false"
+  CORS_ALLOWED_HOSTS: "*"

--- a/infra/helm/auth-service/prod/values-prod.yaml
+++ b/infra/helm/auth-service/prod/values-prod.yaml
@@ -1,0 +1,21 @@
+replicaCount: 2
+
+ingress:
+  enabled: true
+  tls: true
+
+hpa:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+
+serviceMonitor:
+  enabled: true
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi

--- a/infra/helm/auth-service/templates/NOTES.txt
+++ b/infra/helm/auth-service/templates/NOTES.txt
@@ -1,0 +1,9 @@
+auth-service deployed!
+
+{{- if .Values.ingress.enabled }}
+URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}/graphql
+GraphQL Playground: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}/graphiql
+{{- else }}
+kubectl port-forward svc/{{ include "auth-service.fullname" . }} 8080:8080
+URL: http://localhost:8080/graphql
+{{- end }}

--- a/infra/helm/auth-service/templates/_helpers.tpl
+++ b/infra/helm/auth-service/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "auth-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "auth-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "auth-service.labels" -}}
+helm.sh/chart: {{ include "auth-service.chart" . }}
+{{ include "auth-service.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "auth-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "auth-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "auth-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/infra/helm/auth-service/templates/deployment.yaml
+++ b/infra/helm/auth-service/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "auth-service.fullname" . }}
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "auth-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "auth-service.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "auth-service.fullname" . }}-secret
+          env:
+            {{- range $key, $value := .Values.env }}
+            {{- if ne $key "JWT_SECRET" }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/infra/helm/auth-service/templates/hpa.yaml
+++ b/infra/helm/auth-service/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "auth-service.fullname" . }}
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "auth-service.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/auth-service/templates/ingress.yaml
+++ b/infra/helm/auth-service/templates/ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "auth-service.fullname" . }}
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "auth-service.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ include "auth-service.fullname" . }}-tls
+  {{- end }}
+{{- end }}

--- a/infra/helm/auth-service/templates/secret.yaml
+++ b/infra/helm/auth-service/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "auth-service.fullname" . }}-secret
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  JWT_SECRET: {{ .Values.env.JWT_SECRET | quote }}

--- a/infra/helm/auth-service/templates/service.yaml
+++ b/infra/helm/auth-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "auth-service.fullname" . }}
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "auth-service.selectorLabels" . | nindent 4 }}

--- a/infra/helm/auth-service/templates/servicemonitor.yaml
+++ b/infra/helm/auth-service/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "auth-service.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  labels:
+    {{- include "auth-service.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "auth-service.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/infra/helm/auth-service/test/values-test.yaml
+++ b/infra/helm/auth-service/test/values-test.yaml
@@ -1,0 +1,16 @@
+replicaCount: 1
+
+env:
+  STORAGE_IN_MEMORY: "true"
+  STORAGE_BACKEND: "memory"
+
+dragonfly:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/infra/helm/auth-service/values.yaml
+++ b/infra/helm/auth-service/values.yaml
@@ -1,0 +1,55 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/sashaflake/auth-service
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  host: auth.example.com
+  tls: false
+
+env:
+  JWT_SECRET: "change-me"
+  JWT_ISSUER: "auth-service"
+  JWT_AUDIENCE: "auth-service-users"
+  STORAGE_BACKEND: "dragonfly"
+  DRAGONFLY_HOST: '{{ include "auth-service.fullname" . }}-dragonfly-master'
+  DRAGONFLY_PORT: "6379"
+  STORAGE_IN_MEMORY: "false"
+  CORS_ALLOWED_HOSTS: "http://localhost:3000"
+
+dragonfly:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: false
+
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 70
+
+serviceMonitor:
+  enabled: false
+  namespace: monitoring
+  interval: 15s
+  path: /metrics
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/infra/ops/grafana/provisioning/dashboards/dashboard.yml
+++ b/infra/ops/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: auth-service
+    orgId: 1
+    folder: auth-service
+    type: file
+    disableDeletion: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/infra/ops/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/ops/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      timeInterval: '15s'

--- a/infra/ops/nginx/nginx.conf
+++ b/infra/ops/nginx/nginx.conf
@@ -1,0 +1,29 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream app {
+        server app:8080;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location /stub_status {
+            stub_status;
+            allow 127.0.0.1;
+            allow 172.16.0.0/12;
+            deny all;
+        }
+
+        location / {
+            proxy_pass http://app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/infra/ops/prometheus/prometheus.yml
+++ b/infra/ops/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'auth-service'
+    static_configs:
+      - targets: ['app:8080']
+    metrics_path: '/metrics'
+
+  - job_name: 'nginx'
+    static_configs:
+      - targets: ['nginx-exporter:9113']
+
+  - job_name: 'dragonfly'
+    static_configs:
+      - targets: ['dragonfly-exporter:9121']
+
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/infra/terraform/.terraformrc
+++ b/infra/terraform/.terraformrc
@@ -1,0 +1,5 @@
+provider_installation {
+  network_mirror {
+    url = "https://terraform.cloud.ru/"
+  }
+}

--- a/infra/terraform/.tofurc
+++ b/infra/terraform/.tofurc
@@ -1,0 +1,9 @@
+provider_installation {
+   network_mirror {
+      url = "https://terraform.cloud.ru/"
+      include = ["registry.terraform.io/*/*"]
+   }
+   direct {
+      exclude = ["registry.terraform.io/*/*"]
+   }
+}

--- a/infra/terraform/auth-service.tf
+++ b/infra/terraform/auth-service.tf
@@ -1,0 +1,20 @@
+resource "kubernetes_namespace" "auth" {
+  depends_on = [null_resource.helm_deps]
+  metadata {
+    name = var.namespace
+    labels = { "app.kubernetes.io/managed-by" = "terraform" }
+  }
+}
+
+resource "helm_release" "auth_service" {
+  depends_on = [kubernetes_namespace.auth, helm_release.cert_manager, helm_release.ingress_nginx]
+  name       = "auth-service"
+  chart      = "${path.module}/../../infra/helm/auth-service"
+  namespace  = var.namespace
+
+  set { name = "image.repository"; value = var.app_image_repository }
+  set { name = "image.tag";        value = var.app_image_tag }
+  set { name = "ingress.host";     value = var.app_hostname }
+  set_sensitive { name = "env.JWT_SECRET"; value = var.jwt_secret }
+  set { name = "env.STORAGE_IN_MEMORY"; value = "false" }
+}

--- a/infra/terraform/cert-manager.tf
+++ b/infra/terraform/cert-manager.tf
@@ -1,0 +1,14 @@
+resource "helm_release" "cert_manager" {
+  depends_on       = [helm_release.ingress_nginx]
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.14.5"
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}

--- a/infra/terraform/helm-deps.tf
+++ b/infra/terraform/helm-deps.tf
@@ -1,0 +1,9 @@
+resource "null_resource" "helm_deps" {
+  depends_on = [null_resource.k3s_worker]
+  provisioner "local-exec" {
+    command = "helm dependency update ${path.module}/../../infra/helm/auth-service"
+  }
+  triggers = {
+    chart_lock = filemd5("${path.module}/../../infra/helm/auth-service/Chart.yaml")
+  }
+}

--- a/infra/terraform/ingress-nginx.tf
+++ b/infra/terraform/ingress-nginx.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "ingress_nginx" {
+  depends_on       = [null_resource.helm_deps]
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = "4.10.1"
+  namespace        = "ingress-nginx"
+  create_namespace = true
+  timeout          = 300
+}

--- a/infra/terraform/k3s.tf
+++ b/infra/terraform/k3s.tf
@@ -1,0 +1,53 @@
+resource "null_resource" "k3s_master" {
+  connection {
+    type        = "ssh"
+    host        = var.master_ip
+    user        = var.ssh_user
+    private_key = file(var.ssh_private_key_path)
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server --disable traefik' sh -s -",
+      "sudo systemctl enable k3s && sudo systemctl start k3s",
+      "sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s",
+    ]
+  }
+  triggers = { master_ip = var.master_ip }
+}
+
+resource "null_resource" "fetch_kubeconfig" {
+  depends_on = [null_resource.k3s_master]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no ${var.ssh_user}@${var.master_ip} \
+        'sudo cat /etc/rancher/k3s/k3s.yaml' \
+        | sed 's|https://127.0.0.1:6443|https://${var.master_ip}:6443|g' \
+        > ${path.module}/kubeconfig.yaml
+    EOT
+  }
+  triggers = { master_ip = var.master_ip }
+}
+
+resource "null_resource" "fetch_node_token" {
+  depends_on = [null_resource.k3s_master]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no ${var.ssh_user}@${var.master_ip} \
+        'sudo cat /var/lib/rancher/k3s/server/node-token' > ${path.module}/node-token.txt
+    EOT
+  }
+  triggers = { master_ip = var.master_ip }
+}
+
+resource "null_resource" "k3s_worker" {
+  depends_on = [null_resource.k3s_master, null_resource.fetch_node_token, null_resource.fetch_kubeconfig]
+  provisioner "local-exec" {
+    command = <<-EOT
+      NODE_TOKEN=$(cat ${path.module}/node-token.txt | tr -d '\n')
+      ssh -i ${var.ssh_private_key_path} -o StrictHostKeyChecking=no ${var.ssh_user}@${var.master_ip} \
+        "ssh -o StrictHostKeyChecking=no ${var.ssh_user}@${var.master_private_ip} \
+         'curl -sfL https://get.k3s.io | K3S_URL=https://${var.master_private_ip}:6443 K3S_TOKEN=$${NODE_TOKEN} sh -'"
+    EOT
+  }
+  triggers = { master_ip = var.master_ip; worker_ip = var.worker_ip }
+}

--- a/infra/terraform/letsencrypt.tf
+++ b/infra/terraform/letsencrypt.tf
@@ -1,0 +1,25 @@
+resource "null_resource" "letsencrypt_issuer" {
+  count      = 0
+  depends_on = [helm_release.cert_manager]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      kubectl apply -f - <<EOF
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-prod
+      spec:
+        acme:
+          server: https://acme-v02.api.letsencrypt.org/directory
+          email: ${var.letsencrypt_email}
+          privateKeySecretRef:
+            name: letsencrypt-prod
+          solvers:
+          - http01:
+              ingress:
+                class: nginx
+      EOF
+    EOT
+  }
+}

--- a/infra/terraform/monitoring.tf
+++ b/infra/terraform/monitoring.tf
@@ -1,0 +1,27 @@
+resource "helm_release" "kube_prometheus" {
+  depends_on       = [null_resource.helm_deps]
+  name             = "kube-prometheus-stack"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  version          = "58.7.2"
+  namespace        = "monitoring"
+  create_namespace = true
+  set { name = "grafana.adminPassword"; value = var.grafana_admin_password }
+  set { name = "grafana.ingress.enabled"; value = "true" }
+  set { name = "grafana.ingress.hosts[0]"; value = var.grafana_hostname }
+  set { name = "grafana.ingress.ingressClassName"; value = "nginx" }
+  timeout = 600
+}
+
+resource "kubernetes_config_map" "grafana_dashboards" {
+  depends_on = [helm_release.kube_prometheus]
+  metadata {
+    name      = "grafana-dashboards"
+    namespace = "monitoring"
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    for f in fileset("${path.module}/../ops/grafana/dashboards", "*.json") :
+    f => file("${path.module}/../ops/grafana/dashboards/${f}")
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "kubeconfig_path" {
+  value       = "${path.module}/kubeconfig.yaml"
+}
+
+output "master_ip" {
+  value = var.master_ip
+}
+
+output "grafana_url" {
+  value = "http://${var.master_ip}:32000"
+}
+
+output "auth_service_url" {
+  value = "http://${var.master_ip}:30080/graphql"
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,13 @@
+locals {
+  kubeconfig_path = "${path.module}/kubeconfig.yaml"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = local.kubeconfig_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = local.kubeconfig_path
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,17 @@
+master_ip            = "1.2.3.4"
+worker_ip            = "1.2.3.5"
+master_private_ip    = "10.0.0.1"
+ssh_user             = "ubuntu"
+ssh_private_key_path = "~/.ssh/id_rsa"
+
+app_image_tag        = "latest"
+app_image_repository = "ghcr.io/sashaflake/auth-service"
+app_hostname         = "auth.example.com"
+grafana_hostname     = "grafana.example.com"
+letsencrypt_email    = "admin@example.com"
+cors_allowed_hosts   = "https://app.example.com"
+namespace            = "auth"
+
+# Secrets — pass via env, never commit:
+# export TF_VAR_jwt_secret=$(openssl rand -base64 32)
+# export TF_VAR_grafana_admin_password="your-password"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,68 @@
+variable "master_ip" {
+  type        = string
+  description = "Public IP of k3s master node"
+}
+
+variable "worker_ip" {
+  type        = string
+  description = "Public IP of k3s worker node"
+}
+
+variable "master_private_ip" {
+  type        = string
+  description = "Private IP of master node (for k3s agent join)"
+}
+
+variable "ssh_user" {
+  type    = string
+  default = "ubuntu"
+}
+
+variable "ssh_private_key_path" {
+  type    = string
+  default = "~/.ssh/id_rsa"
+}
+
+variable "jwt_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "app_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "app_image_repository" {
+  type    = string
+  default = "ghcr.io/sashaflake/auth-service"
+}
+
+variable "app_hostname" {
+  type    = string
+  default = "auth.example.com"
+}
+
+variable "grafana_hostname" {
+  type    = string
+  default = "grafana.example.com"
+}
+
+variable "grafana_admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "letsencrypt_email" {
+  type = string
+}
+
+variable "cors_allowed_hosts" {
+  type    = string
+  default = "http://localhost:3000"
+}
+
+variable "namespace" {
+  type    = string
+  default = "auth"
+}

--- a/infra/terraform/versions.tf
+++ b/infra/terraform/versions.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.7"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+  # backend "s3" {
+  #   bucket                      = "your-tf-state-bucket"
+  #   key                         = "monorepo/terraform.tfstate"
+  #   region                      = "ru-central1"
+  #   endpoint                    = "https://storage.cloud.ru"
+  #   skip_credentials_validation = true
+  #   skip_metadata_api_check     = true
+  #   skip_region_validation      = true
+  #   force_path_style            = true
+  # }
+}


### PR DESCRIPTION
## Summary

Превращаем `backend` в монорепо — добавляем `infra/` и `frontend/`.

## Новая структура

```
├── auth/          # Backend: Kotlin/Ktor auth service (было)
├── frontend/      # Frontend (пока placeholder, заполняется отдельным PR)
└── infra/         # Infrastructure (перенесено из SashaFlake/infra)
    ├── Dockerfile
    ├── docker-compose.yaml
    ├── helm/auth-service/
    ├── ops/
    └── terraform/
```

## После merge

1. Переименовать репо: GitHub → Settings → Repository name
2. Заархивировать `SashaFlake/infra` и `SashaFlake/frontend`

## Related
- Closes [SashaFlake/infra#1](https://github.com/SashaFlake/infra/pull/1) (superseded)
- Source: [SashaFlake/engineer-challenge](https://github.com/SashaFlake/engineer-challenge)