### PR TITLE
feat: frontend Dockerfile improvements + CI workflow

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,95 @@
+name: Frontend CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'service-mesh/frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'service-mesh/frontend/**'
+      - '.github/workflows/frontend-ci.yml'
+
+defaults:
+  run:
+    working-directory: service-mesh/frontend/service-mesh
+
+jobs:
+  # ── Job 1: lint + typecheck + test ─────────────────────────────────────────
+  quality:
+    name: Lint / Typecheck / Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: service-mesh/frontend/service-mesh/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run test
+
+  # ── Job 2: docker build + push ──────────────────────────────────────────────
+  docker:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    needs: quality
+    # Пушим образ только из PR или веток (не main)
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/frontend-service-mesh
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: service-mesh/frontend/service-mesh
+          file: service-mesh/frontend/service-mesh/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VITE_API_URL=${{ vars.VITE_API_URL || 'http://localhost:4000' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/service-mesh/frontend/service-mesh/Dockerfile
+++ b/service-mesh/frontend/service-mesh/Dockerfile
@@ -1,23 +1,30 @@
-# ── Stage 1: build ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+# ── Stage 1: deps ──────────────────────────────────────────────────────────
+FROM node:22-alpine AS deps
 WORKDIR /app
 
-# ARG пробрасывается из compose build.args
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ── Stage 2: build ─────────────────────────────────────────────────────────
+FROM deps AS builder
+WORKDIR /app
+
+# VITE_API_URL пробрасывается из compose build.args или CI build-arg
 ARG VITE_API_URL=http://localhost:4000
 ENV VITE_API_URL=$VITE_API_URL
-
-COPY package.json ./
-RUN npm install --frozen-lockfile
 
 COPY . .
 RUN npm run build
 
-# ── Stage 2: serve через nginx ─────────────────────────────────────────────
+# ── Stage 3: serve через nginx ──────────────────────────────────────────────
 FROM nginx:1.27-alpine AS runtime
 
-# Конфиг nginx — SPA с fallback на index.html
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Healthcheck для k8s liveness probe
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:80/ || exit 1
 
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Что сделано

### Dockerfile (`service-mesh/frontend/service-mesh/Dockerfile`)
- Разделён на 3 стейджа: `deps` → `builder` → `runtime` (кэш node_modules не инвалидируется при изменении кода)
- `npm install --frozen-lockfile` заменён на `npm ci` (стандартный CI-способ установки, читает `package-lock.json`)
- Добавлен `HEALTHCHECK` для k8s liveness probe

### CI workflow (`.github/workflows/frontend-ci.yml`)
- **Триггер**: любой push в не-`main` ветку + PR в `main`, только при изменениях в `service-mesh/frontend/**`
- **Job `quality`**: `npm ci` → `lint` → `typecheck` → `test`
- **Job `docker`**: запускается после `quality`; собирает образ и пушит в GHCR с тегами по ветке, PR и SHA
- Кэш Docker слоёв через GitHub Actions Cache (`cache-from/to: type=gha`)
- `VITE_API_URL` берётся из `vars.VITE_API_URL` (Repository Variable) с fallback на `localhost:4000`

## Что нужно настроить в репозитории
- `Settings → Variables → Actions` → добавить `VITE_API_URL` (например `https://api.your-cluster.cloud.ru`)
- Разрешить запись в GHCR: `Settings → Actions → General → Workflow permissions → Read and write`