### PR TITLE
chore: remove tailwindcss

### DIFF
--- a/.claude/frontend.md
+++ b/.claude/frontend.md
@@ -7,7 +7,7 @@
 - **Programming Paradigm**: Functional Programming
 - **State Management**: Zustand for global state, React Query for server state
 - **Routing**: TanStack Router
-- **Styling**: Tailwind CSS
+- **Styling**: CSS custom properties (vanilla CSS)
 - **Local-First**: IndexedDB with idb-keyval for offline-first functionality
 - **Testing**: Vitest with React Testing Library
 
@@ -18,7 +18,7 @@
 - Use TypeScript strict mode with proper type definitions
 - Implement local-first architecture with offline capabilities
 - Use React Query for server state synchronization
-- Style with utility-first Tailwind CSS classes
+- Style with CSS custom properties and vanilla CSS
 - Ensure accessibility (WCAG 2.1 AA compliance)
 
 ## Project Structure
@@ -41,7 +41,7 @@
 - Implement proper error boundaries
 - Write comprehensive unit and integration tests
 - Follow React performance best practices
-- Ensure responsive design with Tailwind
+- Ensure responsive design with CSS custom properties
 - Implement proper loading states and error handling
 - Use semantic HTML and ARIA attributes
 
@@ -49,7 +49,7 @@
 ```
 As the Frontend Agent, [task description].
 Use React functional components, TypeScript, DDD principles, and local-first architecture.
-Implement with TanStack Router, Zustand, and Tailwind CSS.
+Implement with TanStack Router and Zustand.
 File: frontend/service-mesh/src/[module]/[layer]/[file].tsx
 ```
 

--- a/service-mesh/.claude/frontend.md
+++ b/service-mesh/.claude/frontend.md
@@ -7,7 +7,7 @@
 - **Programming Paradigm**: Functional Programming
 - **State Management**: Zustand for global state, React Query for server state
 - **Routing**: TanStack Router
-- **Styling**: Tailwind CSS
+- **Styling**: CSS custom properties (vanilla CSS)
 - **Local-First**: IndexedDB with idb-keyval for offline-first functionality
 - **Testing**: Vitest with React Testing Library
 
@@ -18,7 +18,7 @@
 - Use TypeScript strict mode with proper type definitions
 - Implement local-first architecture with offline capabilities
 - Use React Query for server state synchronization
-- Style with utility-first Tailwind CSS classes
+- Style with CSS custom properties and vanilla CSS
 - Ensure accessibility (WCAG 2.1 AA compliance)
 
 ## Project Structure
@@ -41,7 +41,7 @@
 - Implement proper error boundaries
 - Write comprehensive unit and integration tests
 - Follow React performance best practices
-- Ensure responsive design with Tailwind
+- Ensure responsive design with CSS custom properties
 - Implement proper loading states and error handling
 - Use semantic HTML and ARIA attributes
 
@@ -49,7 +49,7 @@
 ```
 As the Frontend Agent, [task description].
 Use React functional components, TypeScript, DDD principles, and local-first architecture.
-Implement with TanStack Router, Zustand, and Tailwind CSS.
+Implement with TanStack Router and Zustand.
 File: frontend/service-mesh/src/[module]/[layer]/[file].tsx
 ```
 

--- a/service-mesh/agents.md
+++ b/service-mesh/agents.md
@@ -13,7 +13,7 @@ This document outlines the specialized agents configured for using Claude AI in 
 ### Frontend Agent
 - **Role**: Manages React frontend development, UI components, routing, and client-side TypeScript code.
 - **Scope**: `frontend/service-mesh/` directory.
-- **Skills**: React, TanStack Router, Tailwind CSS, Vite, testing with Vitest.
+- **Skills**: React, TanStack Router, Vite, CSS custom properties, testing with Vitest.
 - **Configuration**: See `.claude/frontend.md` for detailed guidelines.
 
 ### Infra Agent

--- a/service-mesh/claude.md
+++ b/service-mesh/claude.md
@@ -5,7 +5,7 @@ This document provides instructions and guidelines for using Claude AI effective
 ## Project Overview
 - **Type**: Monorepo with backend (Node.js/TypeScript), frontend (React/TypeScript), and infrastructure components.
 - **Languages**: TypeScript, JavaScript
-- **Frameworks**: Node.js (backend) with Fastify, React (frontend), Express.js, TanStack Router, Tailwind CSS
+- **Frameworks**: Node.js (backend) with Fastify, React (frontend), Express.js, TanStack Router
 - **Tools**: Docker, Helm, Terraform, Prometheus, Grafana
 
 ## Claude Usage Guidelines
@@ -28,7 +28,7 @@ This document provides instructions and guidelines for using Claude AI effective
 - Use React functional components with hooks.
 - Implement proper state management with Zustand or React Query as appropriate.
 - Use TanStack Router for routing.
-- Style with Tailwind CSS classes.
+- Style with CSS custom properties and vanilla CSS.
 - Ensure components are accessible and responsive.
 - Write unit tests with Vitest and React Testing Library.
 

--- a/service-mesh/frontend/FRONTEND_ACTION_PLAN.md
+++ b/service-mesh/frontend/FRONTEND_ACTION_PLAN.md
@@ -1,7 +1,7 @@
 # Frontend Action Plan
 
 > Code review проведён агентом 2026-05-04.  
-> Стек: React 19 + Vite 6 + TanStack Router + TanStack Query + Tailwind 4 + TypeScript 5.7 + Effect.
+> Стек: React 19 + Vite 6 + TanStack Router + TanStack Query + TypeScript 5.7 + Effect.
 
 ---
 

--- a/service-mesh/frontend/service-mesh/README.md
+++ b/service-mesh/frontend/service-mesh/README.md
@@ -8,7 +8,7 @@ Control plane admin interface.
 - **TanStack Router** — type-safe file-based routing
 - **TanStack Query** + localStorage persist — local-first cache
 - **Zustand** — UI state (sidebar, selections)
-- **Tailwind v4** — utility CSS
+- **CSS custom properties** — vanilla CSS styling
 - **Lucide React** — icons
 
 ## Getting Started

--- a/service-mesh/frontend/service-mesh/package.json
+++ b/service-mesh/frontend/service-mesh/package.json
@@ -29,7 +29,6 @@
     "zustand": "^5.0.2"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.0.0",
     "@tanstack/router-cli": "^1.95.0",
     "@tanstack/router-plugin": "^1.95.0",
     "@types/react": "^19.0.0",
@@ -40,7 +39,6 @@
     "@testing-library/user-event": "^14.5.2",
     "@vitest/ui": "^2.0.0",
     "jsdom": "^25.0.0",
-    "tailwindcss": "^4.0.0",
     "typescript": "~5.7.2",
     "vite": "^6.0.5",
     "vitest": "^2.0.0",

--- a/service-mesh/frontend/service-mesh/src/index.css
+++ b/service-mesh/frontend/service-mesh/src/index.css
@@ -1,5 +1,3 @@
-@import "tailwindcss";
-
 :root {
   /* ─── Type scale ─────────────────────────────────── */
   --text-xs:   clamp(0.75rem,  0.7rem  + 0.25vw, 0.875rem);

--- a/service-mesh/frontend/service-mesh/vite.config.ts
+++ b/service-mesh/frontend/service-mesh/vite.config.ts
@@ -1,13 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 export default defineConfig({
   plugins: [
     TanStackRouterVite({ routesDirectory: './src/routes' }),
     react(),
-    tailwindcss(),
   ],
   resolve: {
     alias: {

--- a/service-mesh/prompts.md
+++ b/service-mesh/prompts.md
@@ -30,7 +30,7 @@ File: backend/service-mesh/src/shared/[middleware].ts
 ### React Component
 ```
 As the Frontend Agent, create a new React functional component for [component purpose].
-Use TypeScript, hooks, and Tailwind CSS for styling. Include proper prop types and default values.
+Use TypeScript, hooks, and CSS custom properties for styling. Include proper prop types and default values.
 File: frontend/service-mesh/src/components/[component].tsx
 ```
 


### PR DESCRIPTION
## Что сделано

Удалён TailwindCSS из frontend-приложения.

### Изменения

- **`package.json`** — удалены зависимости `tailwindcss` и `@tailwindcss/vite`
- **`vite.config.ts`** — убран импорт и плагин `tailwindcss()`
- **`src/index.css`** — удалена директива `@import "tailwindcss"`

### После мержа

Запустить `npm install` в `service-mesh/frontend/service-mesh/` для обновления `package-lock.json`.