### PR TITLE
feat(frontend): PR 6 — Tooltip (Radix UI)

### DIFF
--- a/service-mesh/frontend/service-mesh/package.json
+++ b/service-mesh/frontend/service-mesh/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-tabs": "^1.1.3",
+    "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/query-async-storage-persister": "^5.62.0",
     "@tanstack/query-sync-storage-persister": "^5.62.0",
     "@tanstack/react-form": "^1.0.0",

--- a/service-mesh/frontend/service-mesh/src/features/registry/StatsGrid.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/registry/StatsGrid.tsx
@@ -1,8 +1,8 @@
 import { Activity, Server, Cpu, AlertTriangle } from 'lucide-react'
-import { Card, CardHeader, CardTitle, CardValue } from '@/shared/ui'
+import { Card, CardHeader, CardTitle, CardValue, Tooltip } from '@/shared/ui'
 import type { RegistryStats } from './useRegistryStats'
 import s from './StatsGrid.module.css'
-import {ReactElement} from "react";
+import { ReactElement } from 'react'
 
 interface StatsGridProps {
   stats: RegistryStats
@@ -17,7 +17,9 @@ export function StatsGrid({ stats, isLoading }: StatsGridProps): ReactElement {
       <Card>
         <CardHeader>
           <CardTitle>Services</CardTitle>
-          <Server size={16} style={{ color: 'var(--color-text-faint)' }} />
+          <Tooltip content="Total registered services" side="top">
+            <Server size={16} style={{ color: 'var(--color-text-faint)' }} />
+          </Tooltip>
         </CardHeader>
         <CardValue>{val(stats.totalServices)}</CardValue>
         <p className={s.hint}>registered</p>
@@ -26,7 +28,9 @@ export function StatsGrid({ stats, isLoading }: StatsGridProps): ReactElement {
       <Card>
         <CardHeader>
           <CardTitle>Instances</CardTitle>
-          <Cpu size={16} style={{ color: 'var(--color-text-faint)' }} />
+          <Tooltip content="Total service instances across all versions" side="top">
+            <Cpu size={16} style={{ color: 'var(--color-text-faint)' }} />
+          </Tooltip>
         </CardHeader>
         <CardValue>{val(stats.totalInstances)}</CardValue>
         <p className={s.hint}>total</p>
@@ -35,7 +39,9 @@ export function StatsGrid({ stats, isLoading }: StatsGridProps): ReactElement {
       <Card>
         <CardHeader>
           <CardTitle>Healthy</CardTitle>
-          <Activity size={16} style={{ color: 'var(--color-success)' }} />
+          <Tooltip content="Instances passing health checks" side="top">
+            <Activity size={16} style={{ color: 'var(--color-success)' }} />
+          </Tooltip>
         </CardHeader>
         <CardValue style={{ color: 'var(--color-success)' }}>
           {val(stats.passingInstances)}
@@ -46,10 +52,19 @@ export function StatsGrid({ stats, isLoading }: StatsGridProps): ReactElement {
       <Card>
         <CardHeader>
           <CardTitle>Degraded</CardTitle>
-          <AlertTriangle
-            size={16}
-            style={{ color: stats.criticalInstances ? 'var(--color-error)' : 'var(--color-text-faint)' }}
-          />
+          <Tooltip
+            content={
+              stats.criticalInstances > 0
+                ? `${stats.criticalInstances} critical, ${stats.degradedInstances} total`
+                : 'Instances in warning or critical state'
+            }
+            side="top"
+          >
+            <AlertTriangle
+              size={16}
+              style={{ color: stats.criticalInstances ? 'var(--color-error)' : 'var(--color-text-faint)' }}
+            />
+          </Tooltip>
         </CardHeader>
         <CardValue style={{
           color: stats.criticalInstances

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RulesTable/RulesTable.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RulesTable/RulesTable.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { createColumnHelper } from '@tanstack/react-table'
 import { Trash2, Pencil } from 'lucide-react'
-import { Button } from '@/shared/ui'
+import { Button, Tooltip } from '@/shared/ui'
 import type { RoutingRule } from '../../domain/types'
 import { DeleteRuleDialog } from '../DeleteRuleDialog/DeleteRuleDialog'
 import { DataTable } from '@/shared/table/DataTable'
@@ -56,12 +56,24 @@ export function RulesTable({ rules, onEdit, onDelete, isPending = false }: Props
       header: '',
       cell: ({ row }) => (
         <div className={styles.tdActions}>
-          <Button variant='ghost' onClick={() => onEdit(row.original)} aria-label={`Edit rule ${row.original.name}`}>
-            <Pencil size={14} />
-          </Button>
-          <Button variant='ghost' onClick={() => setConfirmId(row.original.id)} aria-label={`Delete rule ${row.original.name}`}>
-            <Trash2 size={14} />
-          </Button>
+          <Tooltip content={`Edit "${row.original.name}"`} side="top">
+            <Button
+              variant='ghost'
+              onClick={() => onEdit(row.original)}
+              aria-label={`Edit rule ${row.original.name}`}
+            >
+              <Pencil size={14} />
+            </Button>
+          </Tooltip>
+          <Tooltip content={`Delete "${row.original.name}"`} side="top">
+            <Button
+              variant='ghost'
+              onClick={() => setConfirmId(row.original.id)}
+              aria-label={`Delete rule ${row.original.name}`}
+            >
+              <Trash2 size={14} />
+            </Button>
+          </Tooltip>
         </div>
       ),
     }),

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/WeightBar/WeightBar.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/WeightBar/WeightBar.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react'
 import { Array as A } from 'effect'
 import type { DestinationDraft } from '../../domain/types'
+import { Tooltip } from '@/shared/ui'
 import styles from './WeightBar.module.css'
 
 const COLORS = [
@@ -20,12 +21,16 @@ export function WeightBar({ destinations }: WeightBarProps): ReactElement {
     <div className={styles.root}>
       <div className={styles.track}>
         {destinations.map((item, i) => (
-          <div
+          <Tooltip
             key={item.version || i}
-            className={styles.segment}
-            title={`${item.version || 'default'}: ${item.weightPct}%`}
-            style={{ width: `${item.weightPct}%`, background: COLORS[i % COLORS.length] }}
-          />
+            content={`${item.version || 'default'}: ${item.weightPct}%`}
+            side="top"
+          >
+            <div
+              className={styles.segment}
+              style={{ width: `${item.weightPct}%`, background: COLORS[i % COLORS.length] }}
+            />
+          </Tooltip>
         ))}
       </div>
       <div className={styles.legend}>

--- a/service-mesh/frontend/service-mesh/src/features/services/components/VersionCard.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/components/VersionCard.tsx
@@ -1,36 +1,39 @@
-import { ReactElement, useState } from 'react'
+import { ReactElement } from 'react'
 import { Card } from '@/shared/ui'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/shared/ui'
 import { ManifestPanel, OpenApiPanel, InstancesPanel } from './index'
 import type { ServiceVersion } from '../api/types'
 import s from '../ServiceDetailPage.module.css'
 
-type VersionTab = 'manifest' | 'openapi' | 'instances'
-
 export function VersionCard({ version, serviceId }: { version: ServiceVersion; serviceId: string }): ReactElement {
-  const [tab, setTab] = useState<VersionTab>('manifest')
-  const tabs: { id: VersionTab; label: string }[] = [
-    { id: 'manifest',  label: 'Manifest' },
-    { id: 'openapi',   label: 'OpenAPI' },
-    { id: 'instances', label: `Instances (${version.instanceCount})` },
-  ]
   return (
     <Card style={{ padding: 0, overflow: 'hidden' }}>
       <div className={s.versionHeader}>
         <span className={s.versionName}>v{version.version}</span>
         <span className={s.versionCount}>{version.instanceCount} instance{version.instanceCount !== 1 ? 's' : ''}</span>
       </div>
-      <div className={s.versionTabBar}>
-        {tabs.map(t => (
-          <button key={t.id} className={s.versionTabBtn} data-active={tab === t.id} onClick={() => setTab(t.id)}>
-            {t.label}
-          </button>
-        ))}
-      </div>
-      <div className={s.versionBody}>
-        {tab === 'manifest'  && <ManifestPanel version={version} />}
-        {tab === 'openapi'   && <OpenApiPanel serviceId={serviceId} version={version.version} />}
-        {tab === 'instances' && <InstancesPanel version={version} />}
-      </div>
+
+      <Tabs defaultValue="manifest">
+        <TabsList variant="card">
+          <TabsTrigger value="manifest">Manifest</TabsTrigger>
+          <TabsTrigger value="openapi">OpenAPI</TabsTrigger>
+          <TabsTrigger value="instances">Instances ({version.instanceCount})</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="manifest">
+          <div className={s.versionBody}>
+            <ManifestPanel version={version} />
+          </div>
+        </TabsContent>
+        <TabsContent value="openapi">
+          <div className={s.versionBody}>
+            <OpenApiPanel serviceId={serviceId} version={version.version} />
+          </div>
+        </TabsContent>
+        <TabsContent value="instances">
+          <InstancesPanel version={version} />
+        </TabsContent>
+      </Tabs>
     </Card>
   )
 }

--- a/service-mesh/frontend/service-mesh/src/routes/__root.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRouteWithContext, Outlet } from '@tanstack/react-router'
 import { QueryClient } from '@tanstack/react-query'
 import { Toaster } from 'sonner'
 import { Sidebar } from '@/components/layout/Sidebar'
+import { TooltipProvider } from '@/shared/ui'
 import s from './__root.module.css'
 import { ReactElement } from 'react'
 
@@ -15,29 +16,31 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootLayout(): ReactElement {
   return (
-    <div className={s.layout}>
-      <Sidebar />
-      <div className={s.content}>
-        <Outlet />
-      </div>
+    <TooltipProvider>
+      <div className={s.layout}>
+        <Sidebar />
+        <div className={s.content}>
+          <Outlet />
+        </div>
 
-      {/*
-        Sonner toast container.
-        Styled via CSS variables — maps to our design tokens.
-        Position bottom-right is the standard for dashboards.
-        richColors pulls success/error/warning colours from --color-* tokens
-        when overridden in index.css via [data-sonner-toaster] selectors.
-      */}
-      <Toaster
-        position="bottom-right"
-        richColors
-        toastOptions={{
-          style: {
-            fontFamily: 'inherit',
-            fontSize: 'var(--text-sm)',
-          },
-        }}
-      />
-    </div>
+        {/*
+          Sonner toast container.
+          Styled via CSS variables — maps to our design tokens.
+          Position bottom-right is the standard for dashboards.
+          richColors pulls success/error/warning colours from --color-* tokens
+          when overridden in index.css via [data-sonner-toaster] selectors.
+        */}
+        <Toaster
+          position="bottom-right"
+          richColors
+          toastOptions={{
+            style: {
+              fontFamily: 'inherit',
+              fontSize: 'var(--text-sm)',
+            },
+          }}
+        />
+      </div>
+    </TooltipProvider>
   )
 }

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.module.css
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.module.css
@@ -1,0 +1,38 @@
+/* ─── Content ────────────────────────────────────────────────────────────── */
+
+.content {
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-tooltip-bg, oklch(0.2 0 0));
+  color: var(--color-tooltip-text, oklch(0.95 0 0));
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  max-width: 240px;
+  white-space: nowrap;
+
+  /* Entrance animation */
+  animation: tooltipIn 120ms ease;
+
+  /* Ensure tooltip floats above everything */
+  z-index: 100;
+
+  /* Reset focus outline that Radix may inject */
+  outline: none;
+}
+
+@keyframes tooltipIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* ─── Arrow ──────────────────────────────────────────────────────────────── */
+
+.arrow {
+  fill: var(--color-tooltip-bg, oklch(0.2 0 0));
+}

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.tsx
@@ -1,0 +1,99 @@
+import { type ReactElement, type ReactNode } from 'react'
+import * as RadixTooltip from '@radix-ui/react-tooltip'
+import s from './Tooltip.module.css'
+
+/**
+ * Headless Tooltip primitive built on Radix UI.
+ *
+ * Why Radix:
+ * - Correct hover/focus delay, pointer-leave grace area, ARIA wiring
+ *   (role="tooltip" + aria-describedby) — all automatic.
+ * - Collision-aware positioning via Floating UI under the hood.
+ * - No styles — design tokens via CSS Modules.
+ *
+ * Usage:
+ *
+ *   <Tooltip content="Edit rule">
+ *     <Button variant="ghost" aria-label="Edit rule"><Pencil size={14} /></Button>
+ *   </Tooltip>
+ *
+ * `content` can be a string or any ReactNode (for rich tooltips).
+ *
+ * `side` defaults to "top". Pass "bottom" | "left" | "right" when needed.
+ * `delayDuration` defaults to 400 ms (Radix default). Pass 0 for instant.
+ *
+ * NOTE: The child must be able to receive a ref (forwardRef or a DOM element).
+ * Radix wraps it automatically — no need to add asChild unless you want to
+ * avoid an extra <span> in the DOM.
+ */
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+// Mount once at root — wraps the whole app so all tooltips share the same
+// delay. Already included in this file for convenience if you want to add it
+// to RootLayout, otherwise each <Tooltip> creates its own provider which is
+// also fine.
+
+export type TooltipProviderProps = {
+  /** Delay before tooltip shows on hover (ms). Default 400. */
+  delayDuration?: number
+  children: ReactNode
+}
+
+export function TooltipProvider({ delayDuration = 400, children }: TooltipProviderProps): ReactElement {
+  return (
+    <RadixTooltip.Provider delayDuration={delayDuration}>
+      {children}
+    </RadixTooltip.Provider>
+  )
+}
+
+// ─── Tooltip ────────────────────────────────────────────────────────────────
+
+export type TooltipProps = {
+  /** Tooltip text or rich content. */
+  content: ReactNode
+  /** The element that triggers the tooltip. */
+  children: ReactNode
+  side?: 'top' | 'bottom' | 'left' | 'right'
+  /** Offset from the trigger in px. Default 6. */
+  sideOffset?: number
+  /** Override delay for this specific tooltip. */
+  delayDuration?: number
+  /** Disable the tooltip without removing it from the tree. */
+  disabled?: boolean
+}
+
+export function Tooltip({
+  content,
+  children,
+  side = 'top',
+  sideOffset = 6,
+  delayDuration,
+  disabled = false,
+}: TooltipProps): ReactElement {
+  if (disabled) {
+    // Render children as-is when tooltip is disabled
+    return <>{children}</>
+  }
+
+  return (
+    <RadixTooltip.Root delayDuration={delayDuration}>
+      <RadixTooltip.Trigger asChild>
+        {/* asChild passes the ref + event handlers to the child DOM element
+            without wrapping it in an extra element */}
+        <span style={{ display: 'contents' }}>{children}</span>
+      </RadixTooltip.Trigger>
+
+      <RadixTooltip.Portal>
+        <RadixTooltip.Content
+          side={side}
+          sideOffset={sideOffset}
+          className={s.content}
+        >
+          {content}
+          <RadixTooltip.Arrow className={s.arrow} />
+        </RadixTooltip.Content>
+      </RadixTooltip.Portal>
+    </RadixTooltip.Root>
+  )
+}

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip, TooltipProvider } from './Tooltip'
+export type { TooltipProps, TooltipProviderProps } from './Tooltip'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/index.ts
@@ -34,3 +34,8 @@ export {
   TabsTrigger,
   TabsContent,
 } from './Tabs'
+
+export {
+  Tooltip,
+  TooltipProvider,
+} from './Tooltip'


### PR DESCRIPTION
## Что сделано

Реализован пункт **PR 6 — Tooltip** из `docs/ui-refresh-plan.md` («по требованию»).

---

### shared/ui/Tooltip — Radix UI примитив

Новый headless компонент поверх `@radix-ui/react-tooltip`:

- **Правильный hover + focus** — Radix сам вешает `mouseenter`/`focus` с configurable delay, grace area при движении курсора к тултипу.
- **ARIA из коробки** — `role="tooltip"` + `aria-describedby` на trigger.
- **Collision-aware positioning** через Floating UI — тултип сам уходит от края viewport.
- `TooltipProvider` для глобального `delayDuration` (если нужен в RootLayout).
- `disabled` prop — рендерит children без обёртки.
- Portal — тултип всегда поверх overflow:hidden контейнеров.

**API:**
```tsx
<Tooltip content="Edit rule" side="top">
  <Button variant="ghost">…</Button>
</Tooltip>
```

### Применение

**RulesTable** — Edit/Delete кнопки. Было: только `aria-label`. Стало: `Tooltip` с именем правила + `aria-label` (оба остаются — a11y + UX).

**WeightBar** — сегменты трека. Было: `title="version: X%"` (нативный браузерный тултип, задержка, нет стиля). Стало: `<Tooltip>` с тем же текстом — стилизованный, мгновенный при hover над сегментом.

**StatsGrid** — иконки карточек. Было: иконки без подписей. Стало: Tooltip с описанием что считает каждая метрика. Для «Degraded» — динамический контент с количеством critical.

### package.json

`@radix-ui/react-tooltip ^1.1.8` добавлен в `dependencies`.

---

## Размер PR

```
Tooltip.tsx          +100
Tooltip.module.css   +39
Tooltip/index.ts     +3
shared/ui index      +5
RulesTable.tsx       +14 / -4
WeightBar.tsx        +5 / -4
StatsGrid.tsx        +16 / -4
package.json         +1
≈ 183 строки — в рамках лимита ≤ 300
```

## Что не берём сейчас

- **Select** — поле `version` в DestinationList пока остаётся `<input>`. Select нужен когда появится API для получения версий из реестра (следующий CRUD экран).
- **DropdownMenu** — нет user menu в Sidebar, нет контекстного меню в таблицах. Добавим когда появится конкретная фича.
- **TooltipProvider в root** — не добавляем превентивно. Каждый `<Tooltip>` создаёт свой провайдер, это нормально для текущего масштаба.