### PR TITLE
docs: update AUDIT files and open-issues tracker

### DIFF
--- a/service-mesh/agents.md
+++ b/service-mesh/agents.md
@@ -16,6 +16,7 @@
 - [File Naming Conventions](#file-naming-conventions)
 - [Common Patterns](#common-patterns)
 - [Anti-Patterns](#anti-patterns)
+- [Open Tasks & Issues Tracking](#open-tasks--issues-tracking)
 - [Entry Points for Common Tasks](#entry-points-for-common-tasks)
 - [Environment Setup](#environment-setup)
 - [Agent Configuration Files](#agent-configuration-files)
@@ -607,10 +608,31 @@ export const deriveStatus = (
 
 ---
 
+## Open Tasks & Issues Tracking
+
+Open tasks, audits, and action plans are stored as **markdown files in the repo** (not in an external issue tracker). When starting work, read these files first to understand the current backlog and compliance gaps.
+
+| File | Purpose | State |
+|---|---|---|
+| `docs/issues/open-issues.md` | Mirror of GitHub Issues (#57–#69). Contains structured issue descriptions with **State:** `open` / `done` / `closed`. | **Primary source** |
+| `frontend/FRONTEND_AUDIT.md` | Compliance audit against AGENTS.md for the frontend. Lists 16 non-compliance items (critical / medium / minor). | Reference |
+| `backend/BACKEND_AUDIT.md` | Compliance audit against AGENTS.md for the backend. Lists 16 non-compliance items (critical / medium / minor). | Reference |
+| `frontend/FRONTEND_ACTION_PLAN.md` | Prioritized action plan from a code review (2026-05-04). 9 tasks rated 🔴 now / 🟡 sprint / 🟠 later / 🔵 long-term. | Reference |
+| `docs/superpowers/plans/` | Design specs and deeper analysis (e.g. RAG usage statistics, type-safety violations, OpenAPI refactoring). | Reference |
+
+**How to use:**
+1. Check `docs/issues/open-issues.md` for the canonical list of open GitHub issues.
+2. Cross-reference with `FRONTEND_AUDIT.md` and `BACKEND_AUDIT.md` for detailed file-level findings.
+3. Use `FRONTEND_ACTION_PLAN.md` for prioritized frontend fixes.
+4. Update these files when an issue is resolved (change **State:** to `done` or add a note).
+
+---
+
 ## Entry Points for Common Tasks
 
 | Task | Where to Start | Key Files |
 |---|---|---|
+| **Find open tasks / issues** | `docs/issues/open-issues.md` | Also see `frontend/FRONTEND_AUDIT.md`, `backend/BACKEND_AUDIT.md`, `frontend/FRONTEND_ACTION_PLAN.md`, and `docs/superpowers/plans/` |
 | Add a new domain entity | `backend/service-mesh/src/modules/[context]/domain/` | `model.ts`, `errors.ts` |
 | Add a new use case | `backend/service-mesh/src/modules/[context]/application/` | `*.service.ts`, `*.service.impl.ts` |
 | Add a new infrastructure adapter | `backend/service-mesh/src/modules/[context]/infrastructure/` | Repository interface + implementation |

--- a/service-mesh/backend/BACKEND_AUDIT.md
+++ b/service-mesh/backend/BACKEND_AUDIT.md
@@ -1,6 +1,6 @@
 # Backend Audit — Non-Compliance with AGENTS.md Requirements
 
-> Audit date: 2026-06-07
+> Audit date: 2026-06-08 (updated)
 > Scope: `backend/service-mesh/`, `backend/mock-service/`
 > Criteria: AGENTS.md (DDD, FP, neverthrow, Zod, naming conventions, JSDoc, tests, etc.)
 
@@ -16,6 +16,8 @@
 
 **AGENTS.md requirement:** «Branded types for IDs: `type ServiceId = string & { readonly _brand: 'ServiceId' }`. Branded type constructors (`serviceId()`, `instanceId()`) prevent raw strings from leaking into domain logic.»
 
+**Tracking:** Issue #59
+
 ---
 
 ### 2. Use of `z.any()` in Zod Contracts
@@ -29,6 +31,8 @@
 
 **AGENTS.md requirement:** «Anti-Pattern: Use `any`. Destroys type safety. Correct Approach: Use `unknown` with Zod/Schema parsing.»
 
+**Tracking:** Issue #58
+
 ---
 
 ### 3. Complete Absence of Tests in the `registry` Module
@@ -41,6 +45,8 @@
 - `presentation/*.http.test.ts`
 
 **AGENTS.md requirement:** «Minimum coverage target: 80%. Tests co-located.»
+
+**Tracking:** Issue #60
 
 ---
 
@@ -96,6 +102,8 @@
 
 **AGENTS.md requirement:** «Repository Pattern and Infrastructure Boundaries — The application layer owns the storage contract. Infrastructure implements it. Future: PostgreSQL persistence is out of MVP scope but must fit the existing repository interface without changing domain or application layers.»
 
+**Tracking:** Issue #57
+
 ---
 
 ### 7. Application Service Methods Return Non-Result Types
@@ -105,6 +113,8 @@
 - `backend/service-mesh/src/modules/routing-rules/application/routing-rule.service.ts` — `list(serviceId: string): RoutingRule[]` (not `Result`)
 
 **AGENTS.md requirement:** «Application services return `Result<T, ErrorType>`. All use-case methods should return `Result`.»
+
+**Tracking:** Issue #59
 
 ---
 
@@ -119,6 +129,8 @@
   - `as InstanceView`
 
 **AGENTS.md requirement:** «Parse, don't validate. Decode at the boundary. Anti-Pattern: Use `any`.»
+
+**Tracking:** Issue #58
 
 ---
 
@@ -141,6 +153,8 @@
 **Problem:** Domain types are declared as `interface` with **mutable** fields (no `readonly`).
 
 **AGENTS.md requirement:** «All value objects are immutable.»
+
+**Tracking:** Issue #61
 
 ---
 
@@ -180,9 +194,21 @@ Expected network/registration errors are handled via `throw` instead of `Result<
 
 ---
 
+### 14. `recordHealthCheck` Silently Swallows "instance not found"
+
+**Where:** `backend/service-mesh/src/modules/registry/application/registry.service.ts`
+
+**Problem:** `recordHealthCheck()` returns `void` and does nothing when the instance doesn't exist. Missing else branch — error swallowed.
+
+**AGENTS.md requirement:** «No exceptions for expected errors. Return `Result<T, E>` via neverthrow.»
+
+**Tracking:** Issue #61
+
+---
+
 ## 🟢 Minor Non-Compliance Issues
 
-### 14. Inconsistent Validation Approach in Registry Routes
+### 15. Inconsistent Validation Approach in Registry Routes
 
 **Where:** `backend/service-mesh/src/modules/registry/presentation/routes.ts`
 
@@ -192,7 +218,7 @@ Expected network/registration errors are handled via `throw` instead of `Result<
 
 ---
 
-### 15. `try/catch` for Upstream Fetch in Handler
+### 16. `try/catch` for Upstream Fetch in Handler
 
 **Where:** `backend/service-mesh/src/modules/registry/presentation/handlers/service.handlers.ts` — `getOpenApi`
 
@@ -202,7 +228,7 @@ Expected network/registration errors are handled via `throw` instead of `Result<
 
 ---
 
-### 16. Retry Logic via `for` in `mock-service`
+### 17. Retry Logic via `for` in `mock-service`
 
 **Where:** `backend/mock-service/src/index.ts`
 
@@ -216,6 +242,6 @@ Expected network/registration errors are handled via `throw` instead of `Result<
 
 | Level | Count | Examples |
 |---|---|---|
-| 🔴 Critical | ~15 | Missing branded types in routing-rules; `z.any()` in contracts; absence of tests in registry; naming convention violations; missing JSDoc; missing Repository pattern; non-Result return types |
-| 🟡 Medium | ~8 | `console.error` in `env.ts`; `for...of` instead of reduce; unsafe `as` in mock-service; mutable `interface` in routing-rules domain; `throw` in mock-service; no env validation in mock-service |
-| 🟢 Minor | ~3 | Inconsistent validation in registry routes; `try/catch` in handler; retry loop in mock-service |
+| 🔴 Critical | 8 | Missing branded types in routing-rules; `z.any()` in contracts; absence of tests in registry; naming convention violations; missing JSDoc; missing Repository pattern; non-Result return types; unsafe `as` assertions |
+| 🟡 Medium | 6 | `console.error` in `env.ts`; `for...of` instead of reduce; `throw` in mock-service; mutable `interface` in routing-rules domain; no env validation in mock-service; `recordHealthCheck` swallows errors |
+| 🟢 Minor | 3 | Inconsistent validation in registry routes; `try/catch` in handler; retry loop in mock-service |

--- a/service-mesh/docs/issues/open-issues.md
+++ b/service-mesh/docs/issues/open-issues.md
@@ -1,5 +1,5 @@
 # Открытые GitHub Issues — SashaFlake/monorepo
-Всего открытых: 7
+Всего открытых: 5 (все backend)
 ---
 
 ## [Issue #57] [Backend] Missing Repository Pattern — application layer tightly coupled to in-memory Maps

--- a/service-mesh/frontend/FRONTEND_AUDIT.md
+++ b/service-mesh/frontend/FRONTEND_AUDIT.md
@@ -1,112 +1,26 @@
 # Frontend Audit — Non-Compliance with AGENTS.md Requirements
 
-> Audit date: 2026-06-07
+> Audit date: 2026-06-08 (updated)
 > Scope: `frontend/service-mesh/src/`
 > Criteria: AGENTS.md (DDD layers, Effect, TanStack Query, CSS Modules, JSDoc, tests, etc.)
 
 ---
 
-## 🔴 Critical Non-Compliance Issues
+## ✅ Resolved Critical Issues (verified 2026-06-08)
 
-### 1. Missing DDD Layers in `registry` and `services` Features
+The following critical issues were fixed in issues #62, #63, #64, #65, #66, #69:
 
-**Where:**
-- `frontend/service-mesh/src/features/registry/`
-- `frontend/service-mesh/src/features/services/`
-
-**Problem:** Neither feature follows the required DDD layer structure (`domain/`, `application/`, `infrastructure/`, `ui/`).
-
-- `features/registry/` contains components and a hook flat in the feature root:
-  - `RegistryDashboard.tsx`, `ServicesTable.tsx`, `StatsGrid.tsx`, `useRegistryStats.ts`
-  - No `domain/`, `application/`, `infrastructure/`, `ui/` directories.
-- `features/services/` uses non-standard `api/` and `components/` instead of DDD layers:
-  - `api/api.ts`, `api/types.ts`
-  - `components/InstancesPanel.tsx`, `components/OpenApiPanel.tsx`, etc.
-
-**AGENTS.md requirement:** «Code is organized by features and layers: Domain, Application, Infrastructure, UI.»
+| # | Issue | Resolution |
+|---|---|---|
+| 1 | Missing DDD Layers in `registry` and `services` | Both features now have `domain/`, `application/`, `infrastructure/`, `ui/` layers |
+| 2 | `useQuery` called directly in UI components | All server-state hooks moved to `application/` layer; components receive data via props |
+| 3 | Type safety violations (`any`, unsafe `as`, inline styles) | `ColumnDef` fixed, `lib/http.ts` uses `Schema.decodeUnknown`, inline styles removed |
+| 4 | Complete absence of tests in `registry`, `services`, `shared` | Co-located tests added across all flagged areas; coverage baseline established |
+| 5 | `ServiceDetailPage` monolith + duplicate components | File reduced from 258 → ~61 lines; sub-components extracted to separate files |
 
 ---
 
-### 2. `useQuery` Called Directly in UI Components
-
-**Where:**
-- `frontend/service-mesh/src/features/services/ServicesPage.tsx:12-17`
-- `frontend/service-mesh/src/features/services/ServiceDetailPage.tsx:213-218`
-- `frontend/service-mesh/src/features/services/components/OpenApiPanel.tsx:76-81`
-- `frontend/service-mesh/src/features/registry/useRegistryStats.ts:41-46`
-
-**Problem:** Server-state hooks (`useQuery`) are called directly inside React UI components instead of being encapsulated in the `application/` layer.
-
-- `ServicesPage` calls `useQuery({ queryKey: registryKeys.list(), queryFn: registryApi.listServices })`
-- `ServiceDetailPage` calls `useQuery({ queryKey: registryKeys.versions(serviceId), queryFn: () => registryApi.getServiceVersions(serviceId) })`
-- `OpenApiPanel` (a presentational component) also calls `useQuery` directly.
-- `useRegistryStats` lives in `features/registry/` root instead of `features/registry/application/`.
-
-**AGENTS.md requirement:** «Application layer — Hooks, use cases, state management (TanStack Query hooks). Presentation layer should not know about query keys or API clients.»
-
----
-
-### 3. Type Safety Violations: `any`, Unsafe Assertions, Inline Styles
-
-**Where:**
-- `frontend/service-mesh/src/shared/table/DataTable.tsx:12-13`
-  - `// eslint-disable-next-line @typescript-eslint/no-explicit-any` + `columns: ColumnDef<TData, any>[]`
-- `frontend/service-mesh/src/lib/http.ts:62`
-  - `res.json() as Promise<T>` — force-casting the entire response body.
-- `frontend/service-mesh/src/features/services/ServiceDetailPage.tsx:92`
-  - `const doc = data as OpenApiDoc` — unsafe type assertion on API response.
-- `frontend/service-mesh/src/features/services/ServiceDetailPage.tsx:98`
-  - `const operation = op as OpenApiOperation` — unsafe assertion inside `Object.entries` loop.
-- `frontend/service-mesh/src/features/services/ServiceDetailPage.tsx:28,57,122,124,181`
-  - Multiple inline `style={{ ... }}` props instead of CSS Module classes.
-- `frontend/service-mesh/src/features/registry/StatsGrid.tsx`
-  - Inline styles: `style={{ color: 'var(--color-text-faint)' }}` etc.
-- `frontend/service-mesh/src/features/routing-rules/ui/RulesTable/RulesTable.tsx:84`
-  - Inline styles for empty state.
-- `frontend/service-mesh/src/shared/table/DataTable.tsx:54`
-  - Inline `style={onRowClick ? { cursor: 'pointer' } : undefined}`.
-
-**AGENTS.md requirements:**
-- «Anti-Pattern: Use `any`. Destroys type safety.»
-- «Parse, don't validate. Decode at the boundary.»
-- «CSS Modules + CSS custom properties — no Tailwind, write scoped styles in `*.module.css`.»
-
----
-
-### 4. Complete Absence of Tests in `registry`, `services`, `shared`
-
-**Where:**
-- `frontend/service-mesh/src/features/registry/` — no tests
-- `frontend/service-mesh/src/features/services/` — no tests
-- `frontend/service-mesh/src/shared/table/DataTable.tsx` — no tests
-- `frontend/service-mesh/src/shared/ui/` — no tests for design-system primitives
-- `frontend/service-mesh/src/routes/` — no tests
-- `frontend/service-mesh/src/components/layout/` — no tests
-- `frontend/service-mesh/src/lib/http.ts` — no tests
-
-**Problem:** Two of the three main features (`registry`, `services`) have zero test coverage. The only tests that exist are in `routing-rules` (`DestinationList.test.tsx`, `RulesTable.test.tsx`, `WeightBar.test.tsx`, `schema.test.ts`) and `shared/form/schemaResolver.test.ts`.
-
-**AGENTS.md requirement:** «Frontend testing: Vitest + jsdom + React Testing Library. Minimum coverage target: 80%. Tests co-located.»
-
----
-
-### 5. `ServiceDetailPage` Violates Single-Responsibility — Multiple Components + Duplicates
-
-**Where:** `frontend/service-mesh/src/features/services/ServiceDetailPage.tsx`
-
-**Problem:**
-1. **File is 258 lines** and contains **8 exported/local components**:
-   - `ManifestPanel`, `SpecCard`, `KV`, `OpenApiPanel`, `InstancesPanel`, `VersionCard`, `ServiceDetailPage`
-   - Plus helper types `OpenApiOperation`, `OpenApiRoute`.
-2. **Duplicate components exist**:
-   - `OpenApiPanel` is defined inline in `ServiceDetailPage.tsx` (line 75) AND exists as a separate file `components/OpenApiPanel.tsx`.
-   - `VersionCard` is defined inline in `ServiceDetailPage.tsx` (line 179) AND exists as a separate file `components/VersionCard.tsx`.
-
-**AGENTS.md requirement:** «Entities per file: 1 aggregate root or major function — Extract into separate files.»
-
----
-
-## 🟡 Medium Non-Compliance Issues
+## 🟡 Medium Non-Compliance Issues (still open)
 
 ### 6. Domain Layer Polluted with UI Hooks and Side Effects
 
@@ -122,14 +36,14 @@
 
 ### 7. Naming Convention Violations
 
-| Current Path | Should Be |
-|---|---|
-| `features/registry/useRegistryStats.ts` | `features/registry/application/useRegistryStats.application.ts` |
-| `features/services/api/api.ts` | `features/services/infrastructure/api.infrastructure.ts` |
-| `features/services/api/types.ts` | `features/services/domain/types.ts` |
-| `features/routing-rules/infrastructure/api.ts` | `features/routing-rules/infrastructure/api.infrastructure.ts` |
-| `features/routing-rules/infrastructure/mock.ts` | `features/routing-rules/infrastructure/mock.infrastructure.ts` |
-| `shared/form/schemaResolver.ts` | `shared/form/schemaResolver.domain.ts` or `schemaResolver.application.ts` |
+| Current Path | Should Be | Status |
+|---|---|---|
+| `features/routing-rules/infrastructure/api.ts` | `features/routing-rules/infrastructure/api.infrastructure.ts` | 🔴 open |
+| `features/routing-rules/infrastructure/mock.ts` | `features/routing-rules/infrastructure/mock.infrastructure.ts` | 🔴 open |
+| `shared/form/schemaResolver.ts` | `shared/form/schemaResolver.domain.ts` or `schemaResolver.application.ts` | 🔴 open |
+| `features/registry/useRegistryStats.ts` | `features/registry/application/useRegistryStats.application.ts` | ✅ fixed |
+| `features/services/api/api.ts` | `features/services/infrastructure/api.infrastructure.ts` | ✅ fixed (api/ removed) |
+| `features/services/api/types.ts` | `features/services/domain/types.ts` | ✅ fixed (api/ removed) |
 
 **AGENTS.md requirement:** «Naming conventions: `*.domain.ts`, `*.application.ts`, `*.infrastructure.ts`, `*.module.css`, etc.»
 
@@ -138,8 +52,9 @@
 ### 8. Missing Barrel Exports
 
 **Where:**
-- `frontend/service-mesh/src/features/registry/` — no `index.ts`
 - `frontend/service-mesh/src/shared/table/` — no `index.ts`
+
+**Status:** `features/registry/index.ts` now exists (✅ fixed). `shared/table/index.ts` still missing (🔴 open).
 
 **AGENTS.md requirement:** «Barrel exports — each feature exports its public API through `index.ts`.»
 
@@ -183,7 +98,7 @@
 
 **Where:** Nearly every exported function in the frontend.
 
-**Problem:** Examples include `RegistryDashboard`, `ServicesTable`, `StatsGrid`, `useRegistryStats`, `ServicesPage`, `ServiceDetailPage`, `useRoutingRules`, `useRuleForm`, `routingRulesApi`, `registryApi`, `Header`, `Sidebar`, `useUIStore`, `DataTable`, etc.
+**Problem:** Many exports still lack JSDoc. `registry/` feature has near-zero JSDoc coverage. `services/` and `shared/ui/` partially covered.
 
 **AGENTS.md requirement:** «Every exported function must have a JSDoc comment. Required fields: What it does, Parameters, Return value, Side effects, Domain invariants.»
 
@@ -194,30 +109,32 @@
 ### 13. Import File Extensions in Path Aliases
 
 **Where:** Multiple files import with `.tsx` / `.ts` extensions in path aliases:
-- `features/registry/ServicesTable.tsx:6` — `from "@/shared/table/DataTable.tsx"`
-- `features/services/ServicesPage.tsx:8` — `from "@/features/registry/ServicesTable.tsx"`
-- `features/routing-rules/application/useRuleForm.ts:4` — `from '@/shared/form/schemaResolver.ts'`
-- `features/routing-rules/infrastructure/api.ts:5` — `from '@/lib/http.ts'`
+- `features/routing-rules/application/useRuleForm.ts` — `from '@/shared/form/schemaResolver.ts'`
+- `features/routing-rules/infrastructure/api.ts` — `from '@/lib/http.ts'`
+
+**Status:** `features/registry/ServicesTable.tsx` and `features/services/ServicesPage.tsx` fixed (✅). `useRuleForm.ts` and `api.ts` still have extensions (🟡 partial).
+
+---
 
 ### 14. Deep Imports Instead of Barrel Imports
 
-**Where:**
-- `features/services/ServiceDetailPage.tsx:7` — `import { Tabs, ... } from '@/shared/ui/Tabs'`
-- `features/services/components/VersionCard.tsx:3` — `import { Tabs, ... } from '@/shared/ui/Tabs'`
+**Status:** ✅ Fixed. No deep imports from `@/shared/ui/Tabs` found anywhere.
 
-Should import from `@/shared/ui` barrel.
+---
 
 ### 15. Outdated Comment in Schema File
 
-**Where:** `frontend/service-mesh/src/features/routing-rules/domain/schema.ts:12-16`
+**Where:** `frontend/service-mesh/src/features/routing-rules/domain/schema.ts`
 
-**Problem:** Comment says *"This file intentionally has no consumers yet"*, but `useRuleForm.ts` already imports `RuleFormSchema` from it.
+**Status:** ✅ Fixed. Outdated "no consumers yet" comment removed.
+
+---
 
 ### 16. Potentially Duplicate Route
 
 **Where:** `frontend/service-mesh/src/routes/services.$serviceId.routing-rules.tsx`
 
-**Problem:** This route exists as a standalone page, but `RoutingRulesPage` is also embedded inside `ServiceDetailPage` via `<Tabs>`. Creates architectural inconsistency.
+**Status:** ✅ Fixed. Route no longer exists.
 
 ---
 
@@ -225,6 +142,6 @@ Should import from `@/shared/ui` barrel.
 
 | Level | Count | Examples |
 |---|---|---|
-| 🔴 Critical | 5 | Missing DDD layers; useQuery in UI components; type safety violations (`any`, `as`, inline styles); zero tests in registry/services; ServiceDetailPage monolith + duplicates |
-| 🟡 Medium | 7 | Domain layer polluted with hooks; naming violations; missing barrel exports; non-null assertions; queryClient duplicates persister.ts; UI state in application hooks; missing JSDoc |
-| 🟢 Minor | 4 | Import file extensions; deep imports; outdated comment; duplicate route |
+| ✅ Resolved (was 🔴 Critical) | 5 | Missing DDD layers; useQuery in UI; type safety; zero tests; ServiceDetailPage monolith |
+| 🟡 Medium | 7 | Domain hooks in routing-rules; naming violations; missing barrel exports; non-null assertions; queryClient dup; UI state in app hooks; missing JSDoc |
+| 🟢 Minor | 1 (3 fixed) | Import file extensions (partial) |


### PR DESCRIPTION
- FRONTEND_AUDIT.md: mark all 5 critical issues as resolved (DDD layers, useQuery in UI, type safety, tests, ServiceDetailPage monolith)
- FRONTEND_AUDIT.md: update medium/minor status with partial fixes
- BACKEND_AUDIT.md: update date, add issue tracking links (#57-#61)
- open-issues.md: correct open issue count from 7 to 5