### PR TITLE
fix(frontend): JSDoc 100% coverage + eslint-plugin-jsdoc + persister fixes

### DIFF
--- a/service-mesh/frontend/FRONTEND_AUDIT.md
+++ b/service-mesh/frontend/FRONTEND_AUDIT.md
@@ -1,140 +1,323 @@
 # Frontend Audit — Non-Compliance with AGENTS.md Requirements
 
-> Audit date: 2026-06-08 (updated)
+> Audit date: 2026-06-08 (comprehensive refresh)
 > Scope: `frontend/service-mesh/src/`
-> Criteria: AGENTS.md (DDD layers, Effect, TanStack Query, CSS Modules, JSDoc, tests, etc.)
+> Criteria: AGENTS.md (DDD layers, Effect, TanStack Query, CSS Modules, JSDoc, tests, lint, type safety)
 
 ---
 
-## ✅ Resolved Critical Issues (verified 2026-06-08)
+## Update Log
 
-The following critical issues were fixed in issues #62, #63, #64, #65, #66, #69:
+| Date | What changed |
+|---|---|
+| 2026-06-08 | **JSDoc coverage fixed** — added JSDoc to 200+ exports across `lib/`, `features/`, `shared/ui/`, `routes/`, `components/`, `store/`. Coverage is now **100%** for production code. |
+| 2026-06-08 | **`lib/queryClient.ts` fixed** — now imports `persister` from `./persister` instead of duplicating a localStorage persister. |
+| 2026-06-08 | **`lib/persister.ts` hardened** — added `typeof window !== 'undefined'` guard and a typed `noopStorage` fallback for SSR. |
+| 2026-06-08 | **Missing barrel exports added** — `shared/table/index.ts` and `shared/form/index.ts` now expose public APIs. |
+| 2026-06-08 | **Import extensions cleaned up** — removed `.ts` / `.tsx` extensions from `@/shared/form/schemaResolver`, `@/lib/http`, and `@/shared/table/DataTable` imports. |
+| 2026-06-08 | **ESLint JSDoc plugin configured** — added `eslint-plugin-jsdoc` with rules that enforce JSDoc presence, descriptions, `@returns`, and custom tags (`@sideEffects`, `@invariants`) without duplicating TypeScript types. |
 
-| # | Issue | Resolution |
+---
+
+## Executive Summary
+
+| Category | Status | Notes |
 |---|---|---|
-| 1 | Missing DDD Layers in `registry` and `services` | Both features now have `domain/`, `application/`, `infrastructure/`, `ui/` layers |
-| 2 | `useQuery` called directly in UI components | All server-state hooks moved to `application/` layer; components receive data via props |
-| 3 | Type safety violations (`any`, unsafe `as`, inline styles) | `ColumnDef` fixed, `lib/http.ts` uses `Schema.decodeUnknown`, inline styles removed |
-| 4 | Complete absence of tests in `registry`, `services`, `shared` | Co-located tests added across all flagged areas; coverage baseline established |
-| 5 | `ServiceDetailPage` monolith + duplicate components | File reduced from 258 → ~61 lines; sub-components extracted to separate files |
+| Type-check | ✅ Passes | `npm run typecheck` exits 0 |
+| Unit tests | ✅ 115/115 pass | Vitest + jsdom, ~4.8–5.6 s |
+| Code coverage | ⚠️ 66.77% stmts | Below AGENTS.md target of 80% |
+| ESLint | ❌ 20 errors, 19 warnings | Fails on `npm run lint` (same count as before JSDoc sweep) |
+| JSDoc coverage | ✅ 100% production | All non-test exports now documented |
+| DDD layering | ❌ Critical violations | React hooks + side effects in `domain/`; UI state in `application/` |
+| Local-first persistence | ✅ Fixed | `queryClient.ts` uses `persister.ts`; SSR guard added |
+| Naming conventions | ⚠️ Multiple violations | Missing `*.application.ts`, `*.infrastructure.ts`, `*.types.ts` suffixes |
 
 ---
 
-## 🟡 Medium Non-Compliance Issues (still open)
+## 🔴 Critical Issues
 
-### 6. Domain Layer Polluted with UI Hooks and Side Effects
+### 1. React Hooks and Side Effects in `domain/` Layer
 
 **Where:**
-- `frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesUI.ts`
 - `frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesMutations.ts`
-
-**Problem:** Hooks that manage UI state (`useRoutingRulesUI`) and side effects/mutations (`useRoutingRulesMutations`) live in the `domain/` layer. Domain must be pure types and functions only.
-
-**AGENTS.md requirement:** «Domain — Pure types, branded types, pure functions, business logic. No side effects.»
-
----
-
-### 7. Naming Convention Violations
-
-| Current Path | Should Be | Status |
-|---|---|---|
-| `features/routing-rules/infrastructure/api.ts` | `features/routing-rules/infrastructure/api.infrastructure.ts` | 🔴 open |
-| `features/routing-rules/infrastructure/mock.ts` | `features/routing-rules/infrastructure/mock.infrastructure.ts` | 🔴 open |
-| `shared/form/schemaResolver.ts` | `shared/form/schemaResolver.domain.ts` or `schemaResolver.application.ts` | 🔴 open |
-| `features/registry/useRegistryStats.ts` | `features/registry/application/useRegistryStats.application.ts` | ✅ fixed |
-| `features/services/api/api.ts` | `features/services/infrastructure/api.infrastructure.ts` | ✅ fixed (api/ removed) |
-| `features/services/api/types.ts` | `features/services/domain/types.ts` | ✅ fixed (api/ removed) |
-
-**AGENTS.md requirement:** «Naming conventions: `*.domain.ts`, `*.application.ts`, `*.infrastructure.ts`, `*.module.css`, etc.»
-
----
-
-### 8. Missing Barrel Exports
-
-**Where:**
-- `frontend/service-mesh/src/shared/table/` — no `index.ts`
-
-**Status:** `features/registry/index.ts` now exists (✅ fixed). `shared/table/index.ts` still missing (🔴 open).
-
-**AGENTS.md requirement:** «Barrel exports — each feature exports its public API through `index.ts`.»
-
----
-
-### 9. Non-Null Assertions in Application Hooks
-
-**Where:** `frontend/service-mesh/src/features/routing-rules/application/useRoutingRules.ts:71-72`
+- `frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesUI.ts`
 
 **Problem:**
-- `editRule!.id`
-- `deleteRule!.id`
+- `useRoutingRulesMutations.ts` imports `useMutation` / `useQueryClient` from `@tanstack/react-query` and calls `toast` from `sonner`. These are application-layer concerns.
+- `useRoutingRulesUI.ts` imports `useState` from `react` and manages modal visibility state. UI state belongs in `store/ui.ts` (Zustand) or in the UI layer, never in `domain/`.
 
-**AGENTS.md requirement:** «Explicit error handling — Result<T, E>. Avoid unsafe non-null assertions.»
+**AGENTS.md requirement:**
+> «Domain — Pure types, branded types, pure functions, business logic. No side effects.»
+> «Domain services contain pure logic. Application services orchestrate and handle side effects.»
+
+**Recommended fix:**
+- Move `useRoutingRulesMutations.ts` → `application/useRoutingRulesMutations.application.ts`.
+- Move `useRoutingRulesUI.ts` logic into `store/ui.ts` as `useRoutingRulesUIStore`, or keep it in `application/useRoutingRulesUI.application.ts` at minimum.
 
 ---
 
-### 10. `queryClient.ts` Duplicates `persister.ts` and Uses `window.localStorage` at Module Level
+### 2. UI State Mixed with Server State in `application/` Hook
+
+**Where:**
+- `frontend/service-mesh/src/features/routing-rules/application/useRoutingRules.ts:31-35, 71-72`
+
+**Problem:**
+- `useState` manages `createOpen`, `editRule`, `deleteRule` inside an application hook.
+- Non-null assertions: `editRule!.id`, `deleteRule!.id`.
+
+**AGENTS.md requirement:**
+> «Zustand — used only for pure UI state. Application layer manages server state via TanStack Query.»
+> «Explicit error handling — Result<T, E>. Avoid unsafe non-null assertions.»
+
+**Recommended fix:**
+- Extract modal state into Zustand slice or dedicated UI hook.
+- Replace `!` with explicit guards (already done in `domain/useRoutingRulesMutations.ts`, but `application/useRoutingRules.ts` still uses them).
+
+---
+
+### 3. `queryClient.ts` Duplicates `persister.ts` and Uses `window.localStorage` at Module Level
+
+**Status:** ✅ Fixed (2026-06-08)
 
 **Where:**
 - `frontend/service-mesh/src/lib/queryClient.ts`
 - `frontend/service-mesh/src/lib/persister.ts`
 
-**Problem:** `queryClient.ts` creates its own `localStorage` persister inline, ignoring the existing `persister.ts` which provides an IDB-based persister with SSR-safe fallback. Additionally, `window.localStorage` is accessed at the top level of the module, which can crash in SSR environments.
+**Original problem:**
+- `queryClient.ts` created its own `createSyncStoragePersister({ storage: window.localStorage })` instead of importing the existing `persister` from `./persister.ts`.
+- Both files referenced `window.localStorage` at top-level without `typeof window !== 'undefined'` guard.
 
-**AGENTS.md requirement:** «Local-first — data is cached in localStorage via TanStack Query persist. Use idb-keyval / localStorage persister from `lib/persister.ts`.»
-
----
-
-### 11. UI State Mixed with Server State in Application Hooks
-
-**Where:** `frontend/service-mesh/src/features/routing-rules/application/useRoutingRules.ts:33-35`
-
-**Problem:** `useState` for modal state (`editRule`, `deleteRule`) is mixed inside an application hook that should only manage server state. UI state should be handled by Zustand.
-
-**AGENTS.md requirement:** «Zustand — used only for pure UI state. Application layer manages server state via TanStack Query.»
+**Resolution:**
+- `queryClient.ts` now imports `persister` from `./persister` and delegates persistence to it.
+- `persister.ts` uses `typeof window !== 'undefined'` and falls back to a typed `noopStorage()` in SSR environments.
 
 ---
 
-### 12. Massive Absence of JSDoc
+### 4. Side Effect (`crypto.randomUUID`) in Domain
 
-**Where:** Nearly every exported function in the frontend.
+**Where:**
+- `frontend/service-mesh/src/features/routing-rules/domain/types.ts:22-26`
 
-**Problem:** Many exports still lack JSDoc. `registry/` feature has near-zero JSDoc coverage. `services/` and `shared/ui/` partially covered.
+**Problem:**
+- `emptyDestinationDraft()` calls `crypto.randomUUID()` inside the `domain/` layer. Domain functions must be pure and deterministic.
 
-**AGENTS.md requirement:** «Every exported function must have a JSDoc comment. Required fields: What it does, Parameters, Return value, Side effects, Domain invariants.»
+**AGENTS.md requirement:**
+> «Domain services contain pure functions.»
+> «Pure functions as default — deterministic, no side effects.»
 
----
-
-## 🟢 Minor Non-Compliance Issues
-
-### 13. Import File Extensions in Path Aliases
-
-**Where:** Multiple files import with `.tsx` / `.ts` extensions in path aliases:
-- `features/routing-rules/application/useRuleForm.ts` — `from '@/shared/form/schemaResolver.ts'`
-- `features/routing-rules/infrastructure/api.ts` — `from '@/lib/http.ts'`
-
-**Status:** `features/registry/ServicesTable.tsx` and `features/services/ServicesPage.tsx` fixed (✅). `useRuleForm.ts` and `api.ts` still have extensions (🟡 partial).
+**Recommended fix:**
+- Make `emptyDestinationDraft` accept `id: string` as an argument, or move the factory to `application/` / `infrastructure/`.
 
 ---
 
-### 14. Deep Imports Instead of Barrel Imports
+### 5. Unsafe `as` Casts and `any` Leaks
 
-**Status:** ✅ Fixed. No deep imports from `@/shared/ui/Tabs` found anywhere.
+**Where:**
+- `frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleNameField.tsx:10, 17`
+- `frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleMatchFields.tsx:12, 13, 22`
+- `frontend/service-mesh/src/shared/ui/Skeleton/Skeleton.tsx:27`
+- `frontend/service-mesh/src/features/routing-rules/ui/WeightBar/WeightBar.tsx:35`
+- `frontend/service-mesh/src/lib/http.ts:6, 33`
+- `frontend/service-mesh/src/lib/persister.ts:18`
+
+**Problem:**
+- `AnyFieldApi` from `@tanstack/react-form` typed as `any` causes `no-unsafe-assignment` ESLint errors in `RuleNameField.tsx` and `RuleMatchFields.tsx`.
+- Casts such as `field.state.value as string`, `as React.CSSProperties`, and `import.meta.env.X as string | undefined` bypass the type system.
+- `lib/http.ts:33` uses `(e as ApiError)._tag` inside a type guard. This is functionally a guard, but still relies on `as`.
+
+**AGENTS.md requirement:**
+> «Use `unknown` with Zod/Schema parsing.»
+> «Never do: Use `any`.»
+
+**Recommended fix:**
+- Type `field` with a concrete `FieldApi<RuleFormValues, ...>` generic instead of `AnyFieldApi`.
+- Replace CSS-variable casts with a small typed helper `cssVar(name: string, value: string | number): React.CSSProperties`.
+- Replace `as string | undefined` env casts with a validated env module.
 
 ---
 
-### 15. Outdated Comment in Schema File
+### 6. JSDoc Coverage
 
-**Where:** `frontend/service-mesh/src/features/routing-rules/domain/schema.ts`
+**Status:** ✅ Fixed (2026-06-08)
 
-**Status:** ✅ Fixed. Outdated "no consumers yet" comment removed.
+**Coverage (strict metric, all named exports):**
+
+| Metric | Before | After |
+|---|---|---|
+| Strict (all exports) | ~12–20% | **100%** |
+| Production code (excl. tests / generated) | ~20% | **100%** |
+
+Every exported function, constant, type, interface, and barrel module in `frontend/service-mesh/src/` now carries a JSDoc comment covering purpose, parameters, return value, side effects, and invariants where applicable.
+
+**High-impact areas documented:**
+- `lib/http.ts` — `apiFetchEffect`, `apiFetch`, `apiFetchVoidEffect`, `apiFetchVoid`, `makeApiError`, `isApiError`, `BASE`, `endpoint`.
+- `lib/persister.ts`, `lib/queryClient.ts`, `store/ui.ts`.
+- `features/registry/*` — domain types, `useRegistryStats`, infrastructure, all UI components.
+- `features/services/domain/*` — types, schemas; application hooks; infrastructure client.
+- `features/routing-rules/*` — domain types/schema, application hooks, API client, UI components.
+- `shared/ui/*` — all primitive components and sub-components (`Dialog`, `AlertDialog`, `Tabs`, `Tooltip`, `Button`, `Card`, `Badge`, `Skeleton`, `ErrorCard`).
+- `routes/*.tsx` — every route definition and placeholder page.
+- `components/layout/*` — `Header` and `Sidebar`.
 
 ---
 
-### 16. Potentially Duplicate Route
+## 🟡 Medium Issues
 
-**Where:** `frontend/service-mesh/src/routes/services.$serviceId.routing-rules.tsx`
+### 7. Naming Convention Violations
 
-**Status:** ✅ Fixed. Route no longer exists.
+| Current Path | Should Be | Status |
+|---|---|---|
+| `features/routing-rules/infrastructure/api.ts` | `features/routing-rules/infrastructure/routing-rules.infrastructure.ts` (or `api.infrastructure.ts`) | 🔴 open |
+| `features/routing-rules/infrastructure/mock.ts` | `features/routing-rules/infrastructure/mock.infrastructure.ts` | 🔴 open |
+| `features/routing-rules/application/useRoutingRules.ts` | `features/routing-rules/application/useRoutingRules.application.ts` | 🔴 open |
+| `features/routing-rules/application/useRuleForm.ts` | `features/routing-rules/application/useRuleForm.application.ts` | 🔴 open |
+| `features/registry/domain/types.ts` | `features/registry/domain/registry.types.ts` | 🟡 open |
+| `features/services/domain/types.ts` | `features/services/domain/services.types.ts` | 🟡 open |
+| `features/routing-rules/domain/types.ts` | `features/routing-rules/domain/routing-rules.types.ts` | 🟡 open |
+| `features/services/domain/schema.ts` | `features/services/domain/services.dto.ts` | 🟡 open |
+| `features/routing-rules/domain/schema.ts` | `features/routing-rules/domain/routing-rules.dto.ts` | 🟡 open |
+| `shared/form/schemaResolver.ts` | `shared/form/schemaResolver.domain.ts` or `schemaResolver.application.ts` | 🟡 open |
+
+**AGENTS.md requirement:**
+> «Naming conventions: `*.domain.ts`, `*.application.ts`, `*.infrastructure.ts`, `*.module.css`, etc.»
+
+---
+
+### 8. Import File Extensions in Path Aliases
+
+**Status:** ✅ Fixed (2026-06-08)
+
+**Where:**
+- `features/routing-rules/infrastructure/api.ts` — was `from '@/lib/http.ts'`
+- `features/routing-rules/application/useRuleForm.ts` — was `from '@/shared/form/schemaResolver.ts'`
+- `features/registry/ui/ServicesTable/ServicesTable.tsx` — was `from "@/shared/table/DataTable.tsx"`
+
+All three imports now use extensionless path aliases.
+
+---
+
+### 9. Missing Barrel Exports
+
+**Status:** ✅ Fixed (2026-06-08)
+
+**Added:**
+- `frontend/service-mesh/src/shared/table/index.ts`
+- `frontend/service-mesh/src/shared/form/index.ts`
+
+Both modules now expose their public surface through barrel files with module-level JSDoc.
+
+---
+
+### 10. Cross-Bounded-Context Imports
+
+**Where:**
+- `features/registry/domain/types.ts` — imports `ServiceView` from `@/features/services/domain/types`
+- `features/registry/infrastructure/registry.infrastructure.ts` — re-exports from `@/features/services/infrastructure/services.infrastructure`
+- `features/registry/ui/ServicesTable/ServicesTable.tsx` — imports from `@/features/services/domain/types`
+- `features/registry/application/useRegistryStats.application.ts` — imports from `@/features/services/domain/types`
+- `features/registry/application/useRegistryStats.test.tsx` — imports from `@/features/services/domain/types`
+
+**Problem:**
+The `registry-ui` bounded context reaches directly into the `services` context's `domain/` layer. This violates DDD boundary rules.
+
+**AGENTS.md requirement:**
+> «A bounded context must not import domain types from another context's `domain/` layer. Cross-context communication happens through the application layer or shared kernel (`shared/endpoint-contract.ts`).»
+
+**Recommended fix:**
+- Re-export public types from `features/services/index.ts` and import from the barrel.
+- For shared kernel types, consider moving `ServiceView` / `InstanceStatus` to `shared/types/` or a similar shared contract module.
+
+---
+
+### 11. ESLint Errors Block CI
+
+**Result of `npm run lint`:**
+
+```
+✖ 39 problems (20 errors, 19 warnings)
+```
+
+**Errors by category:**
+
+| File | Errors |
+|---|---|
+| `src/lib/http.test.ts` | 14 errors (`fp/no-mutation`, `no-unsafe-member-access`) |
+| `src/routes/__root.test.tsx` | 1 error (`no-unsafe-assignment`) |
+| `src/routes/services.index.test.tsx` | 1 error (`no-unsafe-assignment`) |
+| `src/features/services/ui/ServiceDetailPage/ServiceDetailPage.test.tsx` | 1 error (`no-unused-vars`) |
+| `src/features/routing-rules/ui/RuleFormModal/RuleNameField.tsx` | 1 error (`no-unsafe-assignment`) |
+| `src/features/routing-rules/ui/RuleFormModal/RuleMatchFields.tsx` | 1 error (`no-unsafe-assignment`) |
+| `src/features/routing-rules/application/useRuleForm.ts` | 1 error (`require-await`) |
+
+**Warnings by category:**
+- 19 warnings for missing explicit return types (`@typescript-eslint/explicit-function-return-type`).
+
+**AGENTS.md requirement:**
+> «Lint: ESLint + typescript-eslint + eslint-plugin-fp. FP enforcement, no mutations.»
+
+**Recommended fix:**
+- Fix the `AnyFieldApi` typing issue to resolve `no-unsafe-assignment`.
+- Rewrite `http.test.ts` mock assignments to avoid direct mutation of `global.fetch`.
+- Add explicit return types to test render helpers and component functions.
+
+---
+
+### 12. Route File Warnings from TanStack Router
+
+**Where:**
+- `src/routes/__root.test.tsx`
+- `src/routes/services.index.test.tsx`
+
+**Problem:**
+TanStack Router CLI warns that these files do not export a `Route` and therefore won't be included in the route tree. Co-located tests inside `routes/` conflict with file-based routing conventions.
+
+**Recommended fix:**
+- Move route tests to `src/routes/__tests__/` or prefix test files with `-` (e.g., `-__root.test.tsx`) so TanStack Router ignores them.
+- Alternatively, configure `routeFileIgnorePattern` in `vite.config.ts` to exclude `*.test.tsx`.
+
+---
+
+### 13. Incorrect Claim in Prior Audit
+
+**Where:**
+- Prior audit stated: `routes/services.$serviceId.routing-rules.tsx` no longer exists (State: ✅ Fixed).
+
+**Problem:**
+The file **still exists** at `frontend/service-mesh/src/routes/services.$serviceId.routing-rules.tsx` and is functional. The prior audit entry was inaccurate.
+
+---
+
+## 🟢 Minor Issues
+
+### 14. Import File Extensions (Partial)
+
+See issue #8. Three path-alias imports still contain `.ts` / `.tsx` extensions.
+
+---
+
+### 15. `ServicesPage` Renders Without `RouterProvider` in Tests
+
+**Where:**
+- `src/features/services/ui/ServicesPage/ServicesPage.test.tsx`
+
+**Problem:**
+Test passes but logs: `useRouter must be used inside a <RouterProvider> component!`
+
+**Recommended fix:**
+Wrap the rendered component in `RouterProvider` or mock `useRouter` from TanStack Router.
+
+---
+
+### 16. `Dialog.test.tsx` Missing `DialogDescription`
+
+**Where:**
+- `src/shared/ui/Dialog/Dialog.test.tsx`
+
+**Problem:**
+Radix warns about missing `aria-describedby` / description in the Dialog test.
+
+**Recommended fix:**
+Add a `DialogDescription` inside the tested Dialog or add `aria-describedby={undefined}` to suppress the warning.
 
 ---
 
@@ -142,6 +325,20 @@ The following critical issues were fixed in issues #62, #63, #64, #65, #66, #69:
 
 | Level | Count | Examples |
 |---|---|---|
-| ✅ Resolved (was 🔴 Critical) | 5 | Missing DDD layers; useQuery in UI; type safety; zero tests; ServiceDetailPage monolith |
-| 🟡 Medium | 7 | Domain hooks in routing-rules; naming violations; missing barrel exports; non-null assertions; queryClient dup; UI state in app hooks; missing JSDoc |
-| 🟢 Minor | 1 (3 fixed) | Import file extensions (partial) |
+| 🔴 Critical | 5 | Hooks in domain; UI state in application; `crypto.randomUUID` in domain; unsafe casts; (JSDoc ✅ fixed) |
+| 🟡 Medium | 5 | Naming violations; cross-context imports; ESLint errors; route warnings; prior audit inaccuracy (persister ✅ fixed; barrel exports ✅ fixed; import extensions ✅ fixed) |
+| 🟢 Minor | 3 | Test warnings (RouterProvider, Dialog description, import extensions) |
+
+---
+
+## Recommended Priority Order
+
+1. ~~**Fix `queryClient.ts` / `persister.ts`**~~ ✅ Done.
+2. **Move React hooks out of `routing-rules/domain/`** — renames + moves only.
+3. **Extract UI state from `application/useRoutingRules.ts`** — move modal state to Zustand.
+4. **Resolve ESLint errors** — unblock `npm run lint`.
+5. ~~**Add JSDoc to `lib/http.ts`, `features/registry/*`, `features/services/domain/*`**~~ ✅ Done — 100% production coverage.
+6. **Fix cross-context imports** — move shared types to a kernel or use barrel exports.
+7. **Rename files to match naming conventions**.
+8. ~~**Add missing barrel exports** for `shared/table`, `shared/form`.**~~ ✅ Done.
+9. **Improve test coverage** toward 80% target, especially `routing-rules/ui` and `lib/store`.

--- a/service-mesh/frontend/service-mesh/eslint.config.js
+++ b/service-mesh/frontend/service-mesh/eslint.config.js
@@ -2,14 +2,18 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import fp from 'eslint-plugin-fp';
 import reactHooks from 'eslint-plugin-react-hooks';
+import jsdoc from 'eslint-plugin-jsdoc';
 
 export default tseslint.config(
   eslint.configs.recommended,
 
+  // JSDoc base preset — TypeScript-aware (no type duplication in JSDoc).
+  jsdoc.configs['flat/recommended-typescript'],
+
   {
     files: ['src/**/*.{ts,tsx}'],
     extends: [...tseslint.configs.recommendedTypeChecked],
-    plugins: { fp, reactHooks },
+    plugins: { fp, reactHooks, jsdoc },
     rules: {
       // FP rules
       'fp/no-mutation': 'error',
@@ -23,11 +27,91 @@ export default tseslint.config(
       // React Hooks rules
       'reactHooks/rules-of-hooks': 'error',
       'reactHooks/exhaustive-deps': 'warn',
+
+      // JSDoc rules — AGENTS.md requires every exported function to have
+      // JSDoc with: what it does, parameters, return value, side effects,
+      // and domain invariants.
+      //
+      // We keep the rules lightweight: TypeScript already provides types, so
+      // we do not duplicate parameter/return types in JSDoc. We only enforce
+      // the presence of documentation, descriptions, and our custom tags.
+      'jsdoc/require-jsdoc': ['error', {
+        require: {
+          FunctionDeclaration: false,
+          FunctionExpression: false,
+          ArrowFunctionExpression: false,
+          ClassDeclaration: false,
+          ClassExpression: false,
+          MethodDefinition: false,
+        },
+        contexts: [
+          // Exported functions and arrow functions
+          'ExportNamedDeclaration > FunctionDeclaration',
+          'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > ArrowFunctionExpression',
+          'ExportNamedDeclaration > TSDeclareFunction',
+          'MethodDefinition[accessibility="public"]',
+        ],
+        checkConstructors: false,
+        checkGetters: false,
+        checkSetters: false,
+      }],
+      'jsdoc/require-description': ['error', {
+        contexts: [
+          'ExportNamedDeclaration > FunctionDeclaration',
+          'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > ArrowFunctionExpression',
+          'ExportNamedDeclaration > TSDeclareFunction',
+        ],
+        checkConstructors: false,
+      }],
+      // We document parameters through named prop interfaces in TypeScript,
+      // so we do not require (or check) duplicated @param tags.
+      'jsdoc/require-param': 'off',
+      'jsdoc/require-param-description': 'off',
+      'jsdoc/check-param-names': 'off',
+      // We document return semantics in JSDoc, but TS already types them.
+      'jsdoc/require-returns': ['error', {
+        checkConstructors: false,
+        contexts: [
+          'ExportNamedDeclaration > FunctionDeclaration',
+          'ExportNamedDeclaration > VariableDeclaration > VariableDeclarator > ArrowFunctionExpression',
+          'ExportNamedDeclaration > TSDeclareFunction',
+        ],
+      }],
+      'jsdoc/require-returns-description': 'error',
+      'jsdoc/require-returns-check': 'error',
+      // TypeScript already types parameters/returns; no need to duplicate.
+      'jsdoc/require-param-type': 'off',
+      'jsdoc/require-returns-type': 'off',
+      // Formatting / style — kept as warnings so they do not block CI.
+      'jsdoc/check-indentation': 'off',
+      'jsdoc/check-alignment': 'warn',
+      'jsdoc/require-hyphen-before-param-description': 'off',
+      'jsdoc/require-description-complete-sentence': 'off',
+      'jsdoc/tag-lines': 'off',
+      'jsdoc/sort-tags': 'off',
+      'jsdoc/require-throws': 'off',
+      'jsdoc/require-example': 'off',
+      'jsdoc/no-defaults': 'off',
+      // Allow AGENTS.md custom tags: sideEffects, invariants.
+      'jsdoc/check-tag-names': ['warn', {
+        definedTags: ['sideEffects', 'invariants'],
+      }],
+      // Allow JSDoc to reference TS types without importing them as deps.
+      'jsdoc/imports-as-dependencies': 'off',
     },
     languageOptions: {
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    settings: {
+      jsdoc: {
+        mode: 'typescript',
+        tagNamePreference: {
+          returns: 'returns',
+          param: 'param',
+        },
       },
     },
   },

--- a/service-mesh/frontend/service-mesh/package-lock.json
+++ b/service-mesh/frontend/service-mesh/package-lock.json
@@ -43,6 +43,7 @@
         "@vitest/ui": "^2.0.0",
         "eslint": "^10.2.1",
         "eslint-plugin-fp": "^2.3.0",
+        "eslint-plugin-jsdoc": "^63.0.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "jsdom": "^25.0.0",
         "typescript": "~5.7.2",
@@ -537,6 +538,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
+      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment/node_modules/@typescript-eslint/types": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2848,6 +2890,19 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4051,6 +4106,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -4351,6 +4416,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -4795,6 +4870,48 @@
       },
       "peerDependencies": {
         "eslint": ">=3"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.2.tgz",
+      "integrity": "sha512-0TchoK1uS4VxHSo3P4CyWQ31Lm+6zsT+xkHMC5KbFKwgOf8YrXPf1Bl8EP7kpgw1wfe/Ui5jz5mSX7ou8WAVuw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.87.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.2",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -5359,6 +5476,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5608,6 +5742,16 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -5983,6 +6127,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6039,6 +6190,23 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -6386,6 +6554,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -6579,6 +6760,31 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -6823,6 +7029,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/totalist": {

--- a/service-mesh/frontend/service-mesh/package.json
+++ b/service-mesh/frontend/service-mesh/package.json
@@ -50,6 +50,7 @@
     "@vitest/ui": "^2.0.0",
     "eslint": "^10.2.1",
     "eslint-plugin-fp": "^2.3.0",
+    "eslint-plugin-jsdoc": "^63.0.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^25.0.0",
     "typescript": "~5.7.2",

--- a/service-mesh/frontend/service-mesh/src/components/layout/Header.tsx
+++ b/service-mesh/frontend/service-mesh/src/components/layout/Header.tsx
@@ -2,12 +2,29 @@ import { Bell, Search } from 'lucide-react'
 import type {ReactElement, ReactNode} from 'react'
 import s from './Header.module.css'
 
+/**
+ * Props for {@link Header}.
+ */
 type HeaderProps = {
+  /** Page title shown in the largest heading. */
   title: string
+
+  /** Optional subtitle or breadcrumb rendered below the title. */
   subtitle?: ReactNode
+
+  /** Optional action element rendered in the right-hand action area. */
   action?: ReactNode
 }
 
+/**
+ * Top page header with title, optional subtitle, and standard actions.
+ *
+ * @param title    - Page title
+ * @param subtitle - Optional subtitle content
+ * @param action   - Optional action element
+ * @returns The header element
+ * @sideEffects none
+ */
 export function Header({ title, subtitle, action }: HeaderProps): ReactElement {
   return (
     <header className={s.header}>

--- a/service-mesh/frontend/service-mesh/src/features/registry/application/useRegistryStats.application.ts
+++ b/service-mesh/frontend/service-mesh/src/features/registry/application/useRegistryStats.application.ts
@@ -3,6 +3,14 @@ import { registryApi, registryKeys } from '../infrastructure/registry.infrastruc
 import type { ServiceView } from '@/features/services/domain/types'
 import type { RegistryStats, UseRegistryStatsResult } from '../domain/types'
 
+/**
+ * Zero-valued {@link RegistryStats} used as a safe fallback while loading.
+ *
+ * Keeps the UI stable and avoids conditional rendering gymnastics during
+ * the initial fetch.
+ *
+ * @sideEffects none
+ */
 const EMPTY_STATS: RegistryStats = {
   totalServices:     0,
   totalInstances:    0,
@@ -11,6 +19,16 @@ const EMPTY_STATS: RegistryStats = {
   criticalInstances: 0,
 }
 
+/**
+ * Derives aggregate registry statistics from a list of services.
+ *
+ * Flattens instances across services and counts them by status.
+ * Services without instances contribute only to `totalServices`.
+ *
+ * @param services - Array of services returned by the backend
+ * @returns Aggregated {@link RegistryStats}
+ * @sideEffects none
+ */
 const calcStats = (services: ServiceView[]): RegistryStats => {
   const instances = services.flatMap(s => s.instances)
   return {
@@ -22,6 +40,16 @@ const calcStats = (services: ServiceView[]): RegistryStats => {
   }
 }
 
+/**
+ * React hook that loads the service registry and derives dashboard statistics.
+ *
+ * Polls the registry every 10 seconds so the dashboard stays up to date
+ * with heartbeat-driven status changes.
+ *
+ * @returns Object containing stats, services, and UI flags (see {@link UseRegistryStatsResult})
+ * @sideEffects Subscribes to a TanStack Query observer; performs HTTP GET on
+ *              the `/services` endpoint and re-fetches on the configured interval.
+ */
 export function useRegistryStats(): UseRegistryStatsResult {
   const { data, isLoading, isError, dataUpdatedAt } = useQuery({
     queryKey: registryKeys.list(),

--- a/service-mesh/frontend/service-mesh/src/features/registry/domain/types.ts
+++ b/service-mesh/frontend/service-mesh/src/features/registry/domain/types.ts
@@ -1,17 +1,47 @@
 import type { ServiceView } from '@/features/services/domain/types'
 
+/**
+ * Aggregated health statistics across all registered services.
+ *
+ * Derived from `ServiceView[]` by counting services and instances,
+ * then bucketing instances by their derived status.
+ */
 export type RegistryStats = {
+  /** Number of services returned by the registry. */
   totalServices:     number
+
+  /** Total number of instances across all services. */
   totalInstances:    number
+
+  /** Instances whose status is `passing`. */
   passingInstances:  number
+
+  /** Instances whose status is `warning` or `critical`. */
   degradedInstances: number
+
+  /** Instances whose status is `critical`. */
   criticalInstances: number
 }
 
+/**
+ * Result shape returned by {@link useRegistryStats}.
+ *
+ * Combines the raw service list, derived statistics, loading/error flags,
+ * and a human-readable timestamp of the last successful update.
+ */
 export type UseRegistryStatsResult = {
+  /** Aggregated statistics; zeroed while loading. */
   stats:     RegistryStats
+
+  /** Raw service list returned by the registry endpoint. */
   services:  ServiceView[]
+
+  /** `true` while the initial query fetch is in progress. */
   isLoading: boolean
+
+  /** `true` if the query failed (e.g. backend unreachable). */
   isError:   boolean
+
+  /** Localised time string of the last successful update, or `null` if none. */
   updatedAt: string | null
 }

--- a/service-mesh/frontend/service-mesh/src/features/registry/index.ts
+++ b/service-mesh/frontend/service-mesh/src/features/registry/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public API of the `registry-ui` bounded context.
+ *
+ * Exports the dashboard page, the services table, and the TypeScript types
+ * consumed by the dashboard shell.
+ */
 export { RegistryDashboard } from './ui/RegistryDashboard/RegistryDashboard'
 export { ServicesTable } from './ui/ServicesTable/ServicesTable'
 export type { RegistryStats, UseRegistryStatsResult } from './domain/types'

--- a/service-mesh/frontend/service-mesh/src/features/registry/infrastructure/registry.infrastructure.ts
+++ b/service-mesh/frontend/service-mesh/src/features/registry/infrastructure/registry.infrastructure.ts
@@ -1,1 +1,11 @@
+/**
+ * Public infrastructure surface of the `registry-ui` bounded context.
+ *
+ * Currently re-exports the services API client and query keys from the
+ * `services` context because the registry dashboard consumes the same
+ * `/services` endpoint. Future iterations may split this into a dedicated
+ * registry aggregate endpoint.
+ *
+ * @sideEffects none at import time; delegated HTTP I/O to the re-exported client.
+ */
 export { servicesApi as registryApi, servicesKeys as registryKeys } from '@/features/services/infrastructure/services.infrastructure'

--- a/service-mesh/frontend/service-mesh/src/features/registry/ui/RegistryDashboard/RegistryDashboard.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/registry/ui/RegistryDashboard/RegistryDashboard.tsx
@@ -7,6 +7,17 @@ import { StatsGrid } from '../StatsGrid/StatsGrid'
 import { ServicesTable } from '../ServicesTable/ServicesTable'
 import s from './RegistryDashboard.module.css'
 
+/**
+ * Dashboard page for the Control Plane registry overview.
+ *
+ * Displays aggregate statistics, an error banner when the backend is
+ * unreachable, and a clickable table of services that navigates to the
+ * service detail page.
+ *
+ * @returns The dashboard page element
+ * @sideEffects Calls {@link useRegistryStats} (TanStack Query subscription)
+ *              and {@link useNavigate} (router side effect on row click).
+ */
 export function RegistryDashboard(): ReactElement {
   const navigate = useNavigate()
   const { stats, services, isLoading, isError, updatedAt } = useRegistryStats()

--- a/service-mesh/frontend/service-mesh/src/features/registry/ui/ServicesTable/ServicesTable.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/registry/ui/ServicesTable/ServicesTable.tsx
@@ -3,8 +3,13 @@ import type {ServiceView, InstanceStatus} from '@/features/services/domain/types
 import s from './ServicesTable.module.css'
 import {ReactElement} from "react";
 import {createColumnHelper} from "@tanstack/react-table";
-import {DataTable} from "@/shared/table/DataTable.tsx";
+import {DataTable} from "@/shared/table/DataTable";
 
+/**
+ * Maps an instance status to the Badge variant used by the design system.
+ *
+ * @sideEffects none
+ */
 const STATUS_VARIANT: Record<InstanceStatus, 'success' | 'warning' | 'error'> = {
     passing: 'success',
     warning: 'warning',
@@ -12,6 +17,14 @@ const STATUS_VARIANT: Record<InstanceStatus, 'success' | 'warning' | 'error'> = 
 }
 
 const col = createColumnHelper<ServiceView>()
+
+/**
+ * Column definitions for the services table.
+ *
+ * Renders the service name, labels, instance count, and worst-case status.
+ *
+ * @sideEffects none
+ */
 const columns = [
     col.display({
         id: 'name',
@@ -46,10 +59,26 @@ const columns = [
         ),
     }),
 ]
+
 type Props = {
+  /** Services to render in the table. */
   services: ServiceView[]
+
+  /** Called when the user clicks a table row. */
   onRowClick: (svc: ServiceView) => void
 }
+
+/**
+ * Table of registered services with name, labels, instance count, and status.
+ *
+ * Row clicks are forwarded to `onRowClick` so the parent can handle navigation
+ * or selection without the table knowing about the router.
+ *
+ * @param services   - Array of services to display
+ * @param onRowClick - Row click handler
+ * @returns The rendered table element
+ * @sideEffects none
+ */
 export function ServicesTable({services, onRowClick}: Props): ReactElement {
   return <DataTable data={services} columns={columns} onRowClick={onRowClick} />
 }

--- a/service-mesh/frontend/service-mesh/src/features/registry/ui/StatsGrid/StatsGrid.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/registry/ui/StatsGrid/StatsGrid.tsx
@@ -4,11 +4,29 @@ import type { RegistryStats } from '../../domain/types'
 import s from './StatsGrid.module.css'
 import { ReactElement } from 'react'
 
+/**
+ * Props for {@link StatsGrid}.
+ */
 interface StatsGridProps {
+  /** Aggregated registry statistics. */
   stats: RegistryStats
+
+  /** When `true`, numeric values are replaced with an em dash. */
   isLoading: boolean
 }
 
+/**
+ * Renders a 4-column grid of registry statistics: services, instances,
+ * healthy instances, and degraded/critical instances.
+ *
+ * Each card includes a tooltip explaining the metric and adapts its colour
+ * when critical instances are present.
+ *
+ * @param stats     - Aggregated statistics from the registry
+ * @param isLoading - Whether the underlying query is still loading
+ * @returns The stats grid element
+ * @sideEffects none
+ */
 export function StatsGrid({ stats, isLoading }: StatsGridProps): ReactElement {
   const val = (n: number): number | string => isLoading ? '—' : n
 

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/application/useRoutingRules.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/application/useRoutingRules.ts
@@ -3,6 +3,14 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { routingRulesApi, routingKeys } from '../infrastructure/api'
 import type { RoutingRule, RuleFormValues } from '../domain/types'
 
+/**
+ * Combined server + UI state returned by {@link useRoutingRules}.
+ *
+ * @deprecated The UI-state portion (`createOpen`, `editRule`, `deleteRule` and
+ *             their open/close helpers) should move to a Zustand slice so that
+ *             the application layer only manages server state. Kept here for
+ *             backwards compatibility while the refactor is in progress.
+ */
 export type RoutingRulesState = {
   rules: RoutingRule[]
   isLoading: boolean
@@ -27,6 +35,15 @@ export type RoutingRulesState = {
   isDeleting: boolean
 }
 
+/**
+ * Application hook that loads routing rules for a service and exposes
+ * create/update/delete mutations plus modal visibility state.
+ *
+ * @param serviceId - Identifier of the service whose rules should be loaded
+ * @returns Combined server and UI state (see {@link RoutingRulesState})
+ * @sideEffects Subscribes to a TanStack Query observer, performs HTTP requests,
+ *              and mutates local React state for modal visibility.
+ */
 export function useRoutingRules(serviceId: string): RoutingRulesState {
   const qc = useQueryClient()
 

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/application/useRuleForm.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/application/useRuleForm.ts
@@ -1,13 +1,23 @@
 import { useMemo } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { Equivalence, Array as A } from 'effect'
-import { schemaValidator } from '@/shared/form/schemaResolver.ts'
+import { schemaValidator } from '@/shared/form/schemaResolver'
 import { RuleFormSchema } from '../domain/schema'
 import type { RoutingRule, RuleFormValues, DestinationDraft } from '../domain/types'
 import { DestinationDraftEq } from '../domain/types'
 
 // ── Helpers (pure) ────────────────────────────────────────────────────────────
 
+/**
+ * Converts an existing {@link RoutingRule} into editable form values.
+ *
+ * Destination IDs are regenerated as fresh UUIDs because the backend model
+ * does not expose per-destination client-side identifiers.
+ *
+ * @param rule - Existing rule to edit
+ * @returns Editable form values seeded from the rule (see {@link RuleFormValues})
+ * @sideEffects Calls `crypto.randomUUID()` once per destination.
+ */
 const toFormValues = (rule: RoutingRule): RuleFormValues => ({
   name:         rule.name,
   priority:     rule.priority,
@@ -22,6 +32,13 @@ const toFormValues = (rule: RoutingRule): RuleFormValues => ({
   ),
 })
 
+/**
+ * Default form values for creating a new routing rule.
+ *
+ * @returns Fresh {@link RuleFormValues} with empty name, priority 100,
+ *          empty match, and no destinations
+ * @sideEffects none
+ */
 const defaultValues = (): RuleFormValues => ({
   name:         '',
   priority:     100,
@@ -29,6 +46,14 @@ const defaultValues = (): RuleFormValues => ({
   destinations: [],
 })
 
+/**
+ * Equivalence relation for complete rule form values.
+ *
+ * Compares primitive fields and zips destinations to compare them with
+ * {@link DestinationDraftEq}.
+ *
+ * @sideEffects none
+ */
 const RuleFormEq: Equivalence.Equivalence<RuleFormValues> = Equivalence.make((a, b) =>
   a.name === b.name &&
   a.priority === b.priority &&
@@ -37,10 +62,40 @@ const RuleFormEq: Equivalence.Equivalence<RuleFormValues> = Equivalence.make((a,
   A.zip(a.destinations, b.destinations).every(([da, db]) => DestinationDraftEq(da, db))
 )
 
+/**
+ * Synchronous validator built from {@link RuleFormSchema}.
+ *
+ * @sideEffects none
+ */
 const validate = schemaValidator(RuleFormSchema)
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
+/**
+ * Props accepted by {@link useRuleForm}.
+ */
+export type UseRuleFormInput = {
+  /** Existing rule to populate the form, or `undefined` for creation. */
+  initial: RoutingRule | undefined
+
+  /** Callback invoked with validated form values on submit. */
+  onSubmit: (values: RuleFormValues) => void
+}
+
+/**
+ * Hook that manages the create/edit rule form.
+ *
+ * Wires `@tanstack/react-form` to Effect's {@link RuleFormSchema} for
+ * validation and tracks dirty state with an equivalence relation so the
+ * discard confirmation only appears when the user has actually changed
+ * something.
+ *
+ * @param initial  - Existing rule or `undefined`
+ * @param onSubmit - Submit callback
+ * @returns `{ form, isDirty, fieldError }` for use by {@link RuleFormModal}
+ * @sideEffects Creates a TanStack Form instance; calls `crypto.randomUUID()`
+ *              when converting an existing rule's destinations.
+ */
 export function useRuleForm(
   initial: RoutingRule | undefined,
   onSubmit: (values: RuleFormValues) => void,

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/schema.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/schema.ts
@@ -18,6 +18,11 @@ import { Schema } from 'effect'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * String schema that rejects blank or whitespace-only values.
+ *
+ * @sideEffects none
+ */
 const NonBlankString = Schema.String.pipe(
   Schema.filter(s => s.trim().length > 0 || 'must not be blank'),
 )
@@ -39,6 +44,8 @@ export const RuleMatchSchema = Schema.Struct({
 /**
  * Schema for a single destination draft in the rule form.
  *
+ * Enforces per-destination invariants: non-blank version and weight in 0..100.
+ *
  * @sideEffects none
  */
 export const DestinationDraftSchema = Schema.Struct({
@@ -54,6 +61,13 @@ export const DestinationDraftSchema = Schema.Struct({
 
 /**
  * Schema for the complete rule form, enforcing all domain invariants.
+ *
+ * Validates that:
+ *   - `name` is non-blank
+ *   - `priority` is an integer between 0 and 1000
+ *   - `destinations` is non-empty
+ *   - no two destinations share the same version
+ *   - destination weights sum to exactly 100
  *
  * @sideEffects none
  */
@@ -83,7 +97,14 @@ export const RuleFormSchema = Schema.Struct({
   ),
 })
 
+/**
+ * Encoded (wire) type of {@link RuleFormSchema}.
+ */
 export type RuleFormSchemaInput = Schema.Schema.Encoded<typeof RuleFormSchema>
+
+/**
+ * Decoded (domain) type of {@link RuleFormSchema}.
+ */
 export type RuleFormSchemaOutput = Schema.Schema.Type<typeof RuleFormSchema>
 
 // ── API schemas ──────────────────────────────────────────────────────────────

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/types.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/types.ts
@@ -2,21 +2,46 @@ import { Either, Equivalence } from 'effect'
 
 // ── Validation primitives ────────────────────────────────────────────────────
 
+/**
+ * Single field-level validation error returned by domain validators.
+ *
+ * `field` is the last segment of the JSON path (e.g. `priority`, `name`).
+ * For root-level filters without a specific field, `field` is an empty string.
+ */
 export type ValidationError  = { field: string; message: string }
+
+/**
+ * Validation result: either a successfully validated value or a non-empty
+ * list of {@link ValidationError}.
+ */
 export type ValidationResult<A> = Either.Either<A, ValidationError[]>
 
 // ── DestinationDraft ─────────────────────────────────────────────────────────
 
+/**
+ * Draft destination row used while editing a routing rule in the UI.
+ *
+ * Unlike {@link Destination}, drafts are mutable, may contain empty strings,
+ * and are validated before submission.
+ */
 export type DestinationDraft = {
+  /** Stable row identifier (usually a UUID). */
   id:         string
+
+  /** Optional target service override. */
   serviceId?: string
+
+  /** Target version string (e.g. `v1.2.0`). */
   version:    string
+
+  /** Traffic weight percentage (0–100). */
   weightPct:  number
 }
 
 /**
  * Creates an empty destination draft with a fresh UUID.
  *
+ * @returns A new {@link DestinationDraft} with empty version, zero weight, and a fresh id
  * @sideEffects Calls `crypto.randomUUID()`.
  */
 export const emptyDestinationDraft = (): DestinationDraft => ({
@@ -27,6 +52,9 @@ export const emptyDestinationDraft = (): DestinationDraft => ({
 
 /**
  * Equivalence relation for {@link DestinationDraft}.
+ *
+ * Compares `version`, `weightPct`, and `serviceId`. Two drafts with the
+ * same semantic values but different `id`s are considered equivalent.
  *
  * @sideEffects none
  */
@@ -40,9 +68,10 @@ export const DestinationDraftEq: Equivalence.Equivalence<DestinationDraft> =
 /**
  * Sums the weight percentages of a list of destination drafts.
  *
- * @param destinations – read-only array of drafts
+ * @param destinations - Read-only array of drafts
  * @returns Sum of all `weightPct` values
  * @sideEffects none
+ * @invariants Returns 0 for an empty array.
  */
 export const sumWeights = (destinations: ReadonlyArray<DestinationDraft>): number =>
   destinations.reduce((acc, d) => acc + d.weightPct, 0)
@@ -50,11 +79,11 @@ export const sumWeights = (destinations: ReadonlyArray<DestinationDraft>): numbe
 // ── Destination ──────────────────────────────────────────────────────────────
 
 /**
- * A validated destination.  Previously carried a `_brand` tag, but the branded
- * field was removed so that values decoded from the backend API (plain JSON)
- * align with the domain type without runtime construction.
+ * A validated destination ready for persistence.
  *
- * Validation is still available via {@link Destination.create}.
+ * The branded `_brand` field was intentionally removed so values decoded
+ * from the backend API (plain JSON) align with the domain type without
+ * runtime construction. Validation is available via {@link Destination.create}.
  */
 export type Destination = {
   id:         string
@@ -72,9 +101,10 @@ export const Destination = {
   /**
    * Validates a draft and returns a {@link Destination} on success.
    *
-   * @param raw – draft to validate
-   * @returns `Right(destination)` or `Left(errors)`
+   * @param raw - Draft to validate
+   * @returns `Right(destination)` when valid, otherwise `Left(errors)`
    * @sideEffects none
+   * @invariants `version` must be non-blank; `weightPct` must be in 0..100.
    */
   create: (raw: DestinationDraft): ValidationResult<Destination> => {
     const errors: ValidationError[] = []
@@ -92,7 +122,10 @@ export const Destination = {
   /**
    * Unsafely coerces a draft to a {@link Destination} without validation.
    *
-   * @param raw – draft to coerce
+   * Use only when the draft has already been validated or comes from a
+   * trusted source (e.g. the backend API after schema decoding).
+   *
+   * @param raw - Draft to coerce
    * @returns The same object typed as {@link Destination}
    * @sideEffects none
    */
@@ -101,26 +134,62 @@ export const Destination = {
 
 // ── RuleMatch ────────────────────────────────────────────────────────────────
 
+/**
+ * Match criteria for a routing rule.
+ *
+ * All fields are optional; when multiple are provided they are typically
+ * combined with AND semantics by the data plane.
+ */
 export type RuleMatch = {
+  /** Match requests whose path starts with this prefix. */
   pathPrefix?: string
+
+  /** Match requests that carry these exact header key/value pairs. */
   headers?:    Record<string, string>
 }
 
 // ── RoutingRule ──────────────────────────────────────────────────────────────
 
+/**
+ * Aggregate root of the routing-rules bounded context.
+ *
+ * Represents a named rule owned by a service, containing matchers and
+ * weighted destinations that the data plane applies to incoming requests.
+ */
 export type RoutingRule = {
+  /** Rule identifier assigned by the backend. */
   id:           string
+
+  /** Identifier of the owning service. */
   serviceId:    string
+
+  /** Human-readable rule name. */
   name:         string
+
+  /** Rule priority (higher values are evaluated first). */
   priority:     number
+
+  /** Request matcher. */
   match:        RuleMatch
+
+  /** Weighted destinations for traffic splitting. */
   destinations: Destination[]
+
+  /** ISO-8601 timestamp of creation. */
   createdAt:    string
+
+  /** ISO-8601 timestamp of the last update. */
   updatedAt:    string
 }
 
 // ── RuleFormValues ───────────────────────────────────────────────────────────
 
+/**
+ * Values collected by the create/edit rule form.
+ *
+ * Destinations are stored as {@link DestinationDraft}s so the UI can keep
+ * partially valid rows while the user is still editing.
+ */
 export type RuleFormValues = {
   name:         string
   priority:     number

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesMutations.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesMutations.ts
@@ -4,15 +4,44 @@ import { routingRulesApi, routingKeys } from '../infrastructure/api'
 import type { RuleFormValues } from './types'
 import type { RoutingRulesUIState } from './useRoutingRulesUI'
 
+/**
+ * Create/update/delete mutations exposed by {@link useRoutingRulesMutations}.
+ *
+ * @deprecated This type belongs to the application layer and will move out
+ *             of `domain/` during the pending architectural refactor.
+ */
 export type RoutingRulesMutations = {
+  /** Creates a new routing rule from form values. */
   create:     (values: RuleFormValues) => void
+
+  /** Updates the rule currently held in `ui.editRule`. */
   update:     (values: RuleFormValues) => void
+
+  /** Deletes the rule currently held in `ui.deleteRule`. */
   remove:     () => void
+
+  /** Whether the create mutation is pending. */
   isCreating: boolean
+
+  /** Whether the update mutation is pending. */
   isUpdating: boolean
+
+  /** Whether the delete mutation is pending. */
   isDeleting: boolean
 }
 
+/**
+ * Application hook that exposes create/update/delete mutations for routing
+ * rules of a single service.
+ *
+ * @deprecated Located in `domain/` temporarily; should move to
+ *             `application/useRoutingRulesMutations.application.ts`.
+ * @param serviceId - Identifier of the service whose rules are mutated
+ * @param ui        - Modal state helpers used to close dialogs on success
+ * @returns Mutation callbacks and pending flags
+ * @sideEffects Subscribes to three TanStack Query mutations, invalidates the
+ *              rule list on settle, and shows Sonner toast notifications.
+ */
 export function useRoutingRulesMutations(
   serviceId: string,
   ui: Pick<RoutingRulesUIState, 'editRule' | 'deleteRule' | 'closeCreate' | 'closeEdit' | 'closeDelete'>,

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesUI.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/domain/useRoutingRulesUI.ts
@@ -1,19 +1,49 @@
 import { useState } from 'react'
 import type { RoutingRule } from './types'
 
+/**
+ * UI state tracked for the routing rules page modals.
+ *
+ * @deprecated This hook lives in the `domain/` layer only temporarily.
+ *             UI state should move to a Zustand slice in `store/ui.ts`.
+ */
 export type RoutingRulesUIState = {
+  /** Whether the create-rule modal is open. */
   createOpen: boolean
+
+  /** Rule currently being edited, or `null` if the modal is closed. */
   editRule:   RoutingRule | null
+
+  /** Rule currently pending deletion, or `null` if the dialog is closed. */
   deleteRule: RoutingRule | null
 
+  /** Opens the create-rule modal. */
   openCreate:  () => void
+
+  /** Closes the create-rule modal. */
   closeCreate: () => void
+
+  /** Opens the edit modal for the given rule. */
   openEdit:    (rule: RoutingRule) => void
+
+  /** Closes the edit modal. */
   closeEdit:   () => void
+
+  /** Opens the delete confirmation dialog for the given rule. */
   openDelete:  (rule: RoutingRule) => void
+
+  /** Closes the delete confirmation dialog. */
   closeDelete: () => void
 }
 
+/**
+ * React hook that manages modal visibility state for the routing rules page.
+ *
+ * @deprecated Should be replaced by a Zustand slice. Kept for backwards
+ *             compatibility while the application layer is refactored.
+ * @returns Modal visibility state and open/close helpers
+ * @sideEffects Mutates local React state via `useState`.
+ */
 export function useRoutingRulesUI(): RoutingRulesUIState {
   const [createOpen, setCreateOpen] = useState(false)
   const [editRule,   setEditRule]   = useState<RoutingRule | null>(null)

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/index.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public API of the `routing-rules-ui` bounded context.
+ *
+ * Exports domain types, the REST client, query keys, the application hook,
+ * and the page component used by the service detail tabs.
+ */
 export * from './domain/types'
 export { routingRulesApi, routingKeys } from './infrastructure/api'
 export { useRoutingRules } from './application/useRoutingRules'

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/infrastructure/mock.ts
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/infrastructure/mock.ts
@@ -1,6 +1,15 @@
 import { Destination } from '../domain/types'
 import type { RoutingRule } from '../domain/types'
 
+/**
+ * Mock routing rules for local development and storybook-style testing.
+ *
+ * Uses {@link Destination.unsafe} because these fixtures are hand-authored
+ * and trusted; they skip domain validation to avoid coupling tests to the
+ * validator's exact error messages.
+ *
+ * @sideEffects Calls `crypto.randomUUID()` once per destination when evaluated.
+ */
 export const MOCK_RULES: RoutingRule[] = [
   {
     id: 'rule-1',

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/DeleteRuleDialog/DeleteRuleDialog.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/DeleteRuleDialog/DeleteRuleDialog.tsx
@@ -14,13 +14,35 @@ import {
 import type { RoutingRule } from '../../domain/types'
 import s from './DeleteRuleDialog.module.css'
 
+/**
+ * Props for {@link DeleteRuleDialog}.
+ */
 interface DeleteRuleDialogProps {
+  /** Rule the user wants to delete. */
   rule:       RoutingRule
+
+  /** Whether the delete request is in flight. */
   isPending:  boolean
+
+  /** Called when the user confirms deletion. */
   onConfirm:  () => void
+
+  /** Called when the user cancels or dismisses the dialog. */
   onCancel:   () => void
 }
 
+/**
+ * Confirmation dialog displayed before deleting a routing rule.
+ *
+ * Prevents accidental dismissal while the delete mutation is pending.
+ *
+ * @param rule      - Rule to delete
+ * @param isPending - Whether deletion is in progress
+ * @param onConfirm - Confirm handler
+ * @param onCancel  - Cancel / dismiss handler
+ * @returns The alert dialog element
+ * @sideEffects none
+ */
 export function DeleteRuleDialog({ rule, isPending, onConfirm, onCancel }: DeleteRuleDialogProps): ReactElement {
   // Mounted only while open: any close intent (Escape, Cancel) maps to onCancel.
   const handleOpenChange = (open: boolean): void => {

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/DestinationList/DestinationList.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/DestinationList/DestinationList.tsx
@@ -7,11 +7,27 @@ import { Button } from '@/shared/ui'
 import { WeightBar } from '../WeightBar/WeightBar'
 import s from './DestinationList.module.css'
 
+/**
+ * Props for {@link DestinationList}.
+ */
 type Props = {
+  /** Current destination drafts in the form. */
   destinations: DestinationDraft[]
+
+  /** Called with the updated array whenever the user edits, adds, or removes a row. */
   onChange: (destinations: DestinationDraft[]) => void
 }
 
+/**
+ * Editable list of routing destinations with a live weight-sum indicator
+ * and a visual weight bar.
+ *
+ * @param destinations - Current destination drafts
+ * @param onChange     - Change handler
+ * @returns The destination list element
+ * @sideEffects Calls `emptyDestinationDraft()` (and therefore `crypto.randomUUID()`)
+ *              when the user clicks "Add destination".
+ */
 export function DestinationList({ destinations, onChange }: Props): ReactElement {
   const update = (id: string, patch: Partial<Pick<DestinationDraft, 'version' | 'weightPct'>>): void =>
     onChange(

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RoutingRulesPage.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RoutingRulesPage.tsx
@@ -6,8 +6,25 @@ import { RuleFormModal } from './RuleFormModal/RuleFormModal'
 import { DeleteRuleDialog } from './DeleteRuleDialog/DeleteRuleDialog'
 import s from './RoutingRulesPage.module.css'
 
-type Props = { serviceId: string }
+/**
+ * Props for {@link RoutingRulesPage}.
+ */
+type Props = {
+  /** Identifier of the service whose routing rules are displayed. */
+  serviceId: string
+}
 
+/**
+ * Page component for managing routing rules of a single service.
+ *
+ * Renders a toolbar, a table of rules, and conditional create/edit/delete
+ * modals driven by {@link useRoutingRules}.
+ *
+ * @param serviceId - Service identifier
+ * @returns The routing rules page element
+ * @sideEffects Calls {@link useRoutingRules} (TanStack Query subscription
+ *              and local modal state mutations).
+ */
 export function RoutingRulesPage({ serviceId }: Props): ReactElement {
   const {
     rules, isLoading, isError,

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleMatchFields.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleMatchFields.tsx
@@ -3,11 +3,28 @@ import type { AnyFieldApi } from '@tanstack/react-form'
 import type { RuleFormValues } from '../../domain/types'
 import s from './RuleFormFields.module.css'
 
+/**
+ * Props for {@link RuleMatchFields}.
+ */
 interface RuleMatchFieldsProps {
+  /** TanStack Form field API for `priority`. */
   priorityField:   AnyFieldApi
+
+  /** TanStack Form field API for `match`. */
   pathPrefixField: AnyFieldApi
 }
 
+/**
+ * Form fields for rule priority and path-prefix matcher.
+ *
+ * Renders two inputs side by side and keeps the `match` object immutable
+ * by spreading the existing value when the path prefix changes.
+ *
+ * @param priorityField   - Priority field API
+ * @param pathPrefixField - Match/pathPrefix field API
+ * @returns The match fields element
+ * @sideEffects none
+ */
 export function RuleMatchFields({ priorityField, pathPrefixField }: RuleMatchFieldsProps): ReactElement {
   const priorityError = priorityField.state.meta.errors[0]
   const matchValue = pathPrefixField.state.value as RuleFormValues['match']

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleNameField.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RuleFormModal/RuleNameField.tsx
@@ -2,10 +2,24 @@ import type { ReactElement } from 'react'
 import type { AnyFieldApi } from '@tanstack/react-form'
 import s from './RuleFormFields.module.css'
 
+/**
+ * Props for {@link RuleNameField}.
+ */
 interface RuleNameFieldProps {
+  /** TanStack Form field API for `name`. */
   field: AnyFieldApi
 }
 
+/**
+ * Single-line text input for the routing rule name.
+ *
+ * Displays the first validation error when the field has been touched or
+ * the form has been submitted.
+ *
+ * @param field - Name field API
+ * @returns The rule name field element
+ * @sideEffects none
+ */
 export function RuleNameField({ field }: RuleNameFieldProps): ReactElement {
   const error = field.state.meta.errors[0]
   return (

--- a/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RulesTable/RulesTable.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/routing-rules/ui/RulesTable/RulesTable.tsx
@@ -8,15 +8,38 @@ import { DeleteRuleDialog } from '../DeleteRuleDialog/DeleteRuleDialog'
 import { DataTable } from '@/shared/table/DataTable'
 import styles from './RulesTable.module.css'
 
+/**
+ * Props for {@link RulesTable}.
+ */
 type Props = {
+  /** Routing rules to display. */
   rules: RoutingRule[]
+
+  /** Called when the user chooses to edit a rule. */
   onEdit: (rule: RoutingRule) => void
+
+  /** Called when the user confirms deletion of a rule (by ID). */
   onDelete: (id: string) => void
+
+  /** Whether a delete mutation is in flight. */
   isPending?: boolean
 }
 
 const col = createColumnHelper<RoutingRule>()
 
+/**
+ * Table of routing rules with name, priority, match, destinations, and actions.
+ *
+ * Includes an inline confirmation dialog for deletion so the user must
+ * confirm before `onDelete` is invoked.
+ *
+ * @param rules     - Routing rules to render
+ * @param onEdit    - Edit handler
+ * @param onDelete  - Delete handler
+ * @param isPending - Optional pending flag for the delete mutation
+ * @returns The rules table element
+ * @sideEffects Tracks the ID of the rule pending deletion in local React state.
+ */
 export function RulesTable({ rules, onEdit, onDelete, isPending = false }: Props): ReactElement {
   const [confirmId, setConfirmId] = useState<string | null>(null)
   const confirmRule = rules.find(r => r.id === confirmId)

--- a/service-mesh/frontend/service-mesh/src/features/services/application/useServiceDetail.application.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/application/useServiceDetail.application.ts
@@ -2,6 +2,17 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { servicesApi, servicesKeys } from '../infrastructure/services.infrastructure'
 import type { ServiceVersionsResponse } from '../domain/types'
 
+/**
+ * Loads version-grouped details for a single service.
+ *
+ * Polls every 10 seconds to keep instance lists and manifests in sync with
+ * the data plane.
+ *
+ * @param serviceId - Identifier of the service to load
+ * @returns TanStack Query result wrapping {@link ServiceVersionsResponse}
+ * @sideEffects Subscribes to a TanStack Query observer and performs HTTP GET
+ *              on `/services/{serviceId}/versions`.
+ */
 export function useServiceDetail(serviceId: string): UseQueryResult<ServiceVersionsResponse> {
   return useQuery({
     queryKey: servicesKeys.versions(serviceId),

--- a/service-mesh/frontend/service-mesh/src/features/services/application/useServiceOpenApi.application.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/application/useServiceOpenApi.application.ts
@@ -2,6 +2,19 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { servicesApi, servicesKeys } from '../infrastructure/services.infrastructure'
 import type { OpenApiDoc } from '../domain/types'
 
+/**
+ * Loads the OpenAPI document published by a specific service version.
+ *
+ * Retries are disabled because a missing or malformed OpenAPI document is
+ * usually a configuration problem rather than a transient network failure.
+ *
+ * @param serviceId - Identifier of the service that owns the OpenAPI endpoint
+ * @param version   - Optional version filter; when omitted the backend returns
+ *                    the document for the default/active version
+ * @returns TanStack Query result wrapping {@link OpenApiDoc}
+ * @sideEffects Subscribes to a TanStack Query observer and performs HTTP GET
+ *              on `/services/{serviceId}/openapi`.
+ */
 export function useServiceOpenApi(serviceId: string, version?: string): UseQueryResult<OpenApiDoc> {
   return useQuery({
     queryKey: servicesKeys.openapi(serviceId, version),

--- a/service-mesh/frontend/service-mesh/src/features/services/application/useServices.application.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/application/useServices.application.ts
@@ -2,6 +2,16 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query'
 import { servicesApi, servicesKeys } from '../infrastructure/services.infrastructure'
 import type { ServiceView } from '../domain/types'
 
+/**
+ * Loads the full list of registered services.
+ *
+ * Refetches every 10 seconds so the list stays current with registration
+ * and heartbeat events from the data plane.
+ *
+ * @returns TanStack Query result wrapping an array of {@link ServiceView}
+ * @sideEffects Subscribes to a TanStack Query observer and performs HTTP GET
+ *              on `/services` on the configured interval.
+ */
 export function useServices(): UseQueryResult<ServiceView[]> {
   return useQuery({
     queryKey: servicesKeys.list(),

--- a/service-mesh/frontend/service-mesh/src/features/services/domain/schema.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/domain/schema.ts
@@ -1,5 +1,10 @@
 import { Schema } from 'effect'
 
+/**
+ * Effect schema for {@link InstanceView}.
+ *
+ * Validates the flat instance view returned by the registry backend.
+ */
 export const InstanceViewSchema = Schema.Struct({
   id:              Schema.String,
   serviceId:       Schema.String,
@@ -18,6 +23,9 @@ export const InstanceViewSchema = Schema.Struct({
   status: Schema.Literal('passing', 'warning', 'critical'),
 })
 
+/**
+ * Effect schema for {@link ServiceView}.
+ */
 export const ServiceViewSchema = Schema.Struct({
   id:           Schema.String,
   name:         Schema.String,
@@ -27,6 +35,12 @@ export const ServiceViewSchema = Schema.Struct({
   worstStatus:  Schema.Literal('passing', 'warning', 'critical'),
 })
 
+/**
+ * Effect schema for {@link ServiceVersionsResponse}.
+ *
+ * Note: `manifest` is typed as `Schema.Unknown` because the mock data-plane
+ * may evolve its manifest shape independently of the UI schema.
+ */
 export const ServiceVersionsResponseSchema = Schema.Struct({
   serviceId:   Schema.String,
   serviceName: Schema.String,
@@ -38,6 +52,12 @@ export const ServiceVersionsResponseSchema = Schema.Struct({
   })),
 })
 
+/**
+ * Effect schema for a single OpenAPI operation.
+ *
+ * Captures the fields the UI renders (summary, tags, deprecation); unknown
+ * fields are ignored.
+ */
 export const OpenApiOperationSchema = Schema.Struct({
   summary:     Schema.optional(Schema.String),
   description: Schema.optional(Schema.String),
@@ -46,6 +66,12 @@ export const OpenApiOperationSchema = Schema.Struct({
   deprecated:  Schema.optional(Schema.Boolean),
 })
 
+/**
+ * Effect schema for {@link OpenApiDoc}.
+ *
+ * Keeps most fields optional because the document is produced by arbitrary
+ * services and may be partial.
+ */
 export const OpenApiDocSchema = Schema.Struct({
   openapi: Schema.optional(Schema.String),
   info: Schema.optional(Schema.Struct({

--- a/service-mesh/frontend/service-mesh/src/features/services/domain/types.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/domain/types.ts
@@ -1,36 +1,93 @@
 // ── Services domain types ─────────────────────────────────────────────────────
 // Единственный источник правды для типов домена services/instances/openapi.
 
+/**
+ * Derived health state of a single service instance.
+ *
+ * Computed by the backend from heartbeat TTL and the latest health check.
+ */
 export type InstanceStatus = 'passing' | 'warning' | 'critical'
+
+/**
+ * Free-form key/value labels attached to a service.
+ */
 export type Labels = Record<string, string>
 
+/**
+ * Flat view of a registered service instance returned by the backend.
+ *
+ * Includes identity, network coordinates, metadata, and the latest known
+ * health snapshot.
+ */
 export type InstanceView = {
+  /** Instance identifier assigned on registration. */
   id:              string
+
+  /** Parent service identifier. */
   serviceId:       string
+
+  /** Host address advertised by the instance. */
   host:            string
+
+  /** Port advertised by the instance. */
   port:            number
+
+  /** Relative path the control plane should probe for health checks. */
   healthPath:      string
+
+  /** Opaque metadata dictionary supplied at registration. */
   metadata:        Record<string, string>
+
+  /** ISO-8601 timestamp of when the instance was registered. */
   registeredAt:    string
+
+  /** ISO-8601 timestamp of the most recent heartbeat. */
   lastHeartbeatAt: string
+
+  /** Result of the last explicit health check, or `null` if none ran yet. */
   lastHealthCheck: {
     checkedAt:  string
     ok:         boolean
     statusCode: number | null
     latencyMs:  number
   } | null
+
+  /** Derived aggregate status for display purposes. */
   status: InstanceStatus
 }
 
+/**
+ * Flat view of a registered service returned by the backend.
+ *
+ * The aggregate `worstStatus` reflects the most severe status among the
+ * service's instances.
+ */
 export type ServiceView = {
+  /** Service identifier. */
   id:           string
+
+  /** Human-readable service name. */
   name:         string
+
+  /** Labels attached to the service. */
   labels:       Labels
+
+  /** ISO-8601 timestamp of when the service was created. */
   registeredAt: string
+
+  /** Current instance list for the service. */
   instances:    InstanceView[]
+
+  /** Most severe status across all instances. */
   worstStatus:  InstanceStatus
 }
 
+/**
+ * Mock manifest describing how a service version expects to be exposed.
+ *
+ * This shape is produced by the mock data-plane node and consumed by the
+ * admin UI for the service detail page.
+ */
 export type MockManifest = {
   apiVersion: string
   kind:       string
@@ -48,19 +105,43 @@ export type MockManifest = {
   }
 }
 
+/**
+ * A homogeneous group of instances running the same version of a service.
+ */
 export type ServiceVersion = {
+  /** Version string (e.g. `v1.2.0`). */
   version:       string
+
+  /** Number of instances in this version group. */
   instanceCount: number
+
+  /** Instances belonging to this version. */
   instances:     InstanceView[]
+
+  /** Manifest describing the version's exposure and health configuration. */
   manifest:      MockManifest
 }
 
+/**
+ * Response body for the service versions endpoint.
+ */
 export type ServiceVersionsResponse = {
+  /** Service identifier. */
   serviceId:   string
+
+  /** Human-readable service name. */
   serviceName: string
+
+  /** Version groups returned for the service. */
   versions:    ServiceVersion[]
 }
 
+/**
+ * OpenAPI document exposed by a service version.
+ *
+ * Intentionally permissive: the document is produced by arbitrary services,
+ * so most fields are optional and paths are loosely typed.
+ */
 export type OpenApiDoc = {
   openapi?: string
   info?: { title?: string; version?: string; description?: string }
@@ -76,6 +157,9 @@ export type OpenApiDoc = {
   tags?: Array<{ name: string; description?: string }>
 }
 
+/**
+ * Error shape returned when the OpenAPI endpoint cannot produce a document.
+ */
 export type OpenApiError = {
   error:   string
   message: string

--- a/service-mesh/frontend/service-mesh/src/features/services/index.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Public API of the `services-ui` bounded context.
+ *
+ * Exports the services list page, service detail page, public domain types,
+ * the REST client, query keys, and the TanStack Query hooks used by routes.
+ */
 export { ServicesPage } from './ui/ServicesPage/ServicesPage'
 export { ServiceDetailPage } from './ui/ServiceDetailPage/ServiceDetailPage'
 export type { ServiceView, InstanceStatus } from './domain/types'

--- a/service-mesh/frontend/service-mesh/src/features/services/infrastructure/services.infrastructure.ts
+++ b/service-mesh/frontend/service-mesh/src/features/services/infrastructure/services.infrastructure.ts
@@ -19,26 +19,68 @@ import {
   OpenApiDocSchema,
 } from '../domain/schema'
 
-// ── Query keys ────────────────────────────────────────────────────────────────
-
+/**
+ * TanStack Query keys for the services bounded context.
+ *
+ * Used to tag, invalidate, and refetch service-related queries.
+ *
+ * @sideEffects none
+ */
 export const servicesKeys = {
+  /** Root key shared by all service queries. */
   all:      ['registry'] as const,
+
+  /** Key for the service list query. */
   list:     () => [...servicesKeys.all, 'list']                        as const,
+
+  /** Key for a single service detail query. */
   service:  (id: string) => [...servicesKeys.all, 'service', id]       as const,
+
+  /** Key for the version-grouped detail query. */
   versions: (id: string) => [...servicesKeys.all, 'versions', id]      as const,
+
+  /** Key for the OpenAPI document query. */
   openapi:  (id: string, version?: string) =>
     [...servicesKeys.all, 'openapi', id, version ?? '']                as const,
 }
 
-// ── API client ────────────────────────────────────────────────────────────────
-
+/**
+ * REST client for the services / instances endpoints.
+ *
+ * All methods decode responses through Effect schemas defined in
+ * {@link ../domain/schema} so that runtime validation is enforced at the
+ * infrastructure boundary.
+ *
+ * @sideEffects Performs HTTP requests when called.
+ */
 export const servicesApi = {
+  /**
+   * Fetches the full list of registered services.
+   *
+   * @returns Promise resolving to an array of {@link ServiceView}
+   * @sideEffects HTTP GET `/api/v1/services`
+   */
   listServices: (): Promise<ServiceView[]> =>
     apiFetch(endpoint('/services'), Schema.Array(ServiceViewSchema)),
 
+  /**
+   * Fetches a single service by ID.
+   *
+   * @param id - Service identifier
+   * @returns Promise resolving to {@link ServiceView}
+   * @sideEffects HTTP GET `/api/v1/services/{id}`
+   */
   getService: (id: string): Promise<ServiceView> =>
     apiFetch(endpoint(`/services/${id}`), ServiceViewSchema),
 
+  /**
+   * Registers a new service.
+   *
+   * @param name   - Human-readable service name
+   * @param labels - Optional labels dictionary
+   * @returns Promise resolving to the created {@link ServiceView}
+   * @sideEffects HTTP POST `/api/v1/services`
+   */
   createService: (name: string, labels?: Labels): Promise<ServiceView> =>
     apiFetch(endpoint('/services'), ServiceViewSchema, {
       method: 'POST',
@@ -46,17 +88,46 @@ export const servicesApi = {
       body: JSON.stringify({ name, labels }),
     }),
 
+  /**
+   * Deletes a service by ID.
+   *
+   * @param id - Service identifier
+   * @returns Promise resolving to `void`
+   * @sideEffects HTTP DELETE `/api/v1/services/{id}`
+   */
   deleteService: (id: string): Promise<void> =>
     apiFetchVoid(endpoint(`/services/${id}`), { method: 'DELETE' }),
 
+  /**
+   * Fetches version-grouped details for a service.
+   *
+   * @param id - Service identifier
+   * @returns Promise resolving to {@link ServiceVersionsResponse}
+   * @sideEffects HTTP GET `/api/v1/services/{id}/versions`
+   */
   getServiceVersions: (id: string): Promise<ServiceVersionsResponse> =>
     apiFetch(endpoint(`/services/${id}/versions`), ServiceVersionsResponseSchema),
 
+  /**
+   * Fetches the OpenAPI document published by a service version.
+   *
+   * @param id      - Service identifier
+   * @param version - Optional version query parameter
+   * @returns Promise resolving to {@link OpenApiDoc}
+   * @sideEffects HTTP GET `/api/v1/services/{id}/openapi`
+   */
   getServiceOpenApi: (id: string, version?: string): Promise<OpenApiDoc> => {
     const qs = version ? `?version=${encodeURIComponent(version)}` : ''
     return apiFetch(endpoint(`/services/${id}/openapi${qs}`), OpenApiDocSchema)
   },
 
+  /**
+   * Registers a new instance under an existing service.
+   *
+   * @param input - Instance registration payload
+   * @returns Promise resolving to the created {@link InstanceView}
+   * @sideEffects HTTP POST `/api/v1/instances`
+   */
   registerInstance: (input: {
     serviceId:   string
     host:        string
@@ -70,6 +141,13 @@ export const servicesApi = {
       body: JSON.stringify(input),
     }),
 
+  /**
+   * Deregisters an instance by ID.
+   *
+   * @param id - Instance identifier
+   * @returns Promise resolving to `void`
+   * @sideEffects HTTP DELETE `/api/v1/instances/{id}`
+   */
   deregisterInstance: (id: string): Promise<void> =>
     apiFetchVoid(endpoint(`/instances/${id}`), { method: 'DELETE' }),
 }

--- a/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/ManifestPanel.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/ManifestPanel.tsx
@@ -3,6 +3,16 @@ import type { ServiceVersion } from '../../domain/types'
 import { SpecCard, KV } from './SharedComponents'
 import s from './ServiceDetailPage.module.css'
 
+/**
+ * Renders the mock manifest for a service version.
+ *
+ * Displays metadata (API version, kind, generation time) and a grid of
+ * specification cards covering exposure, ports, routing, and health.
+ *
+ * @param version - Service version whose manifest should be rendered
+ * @returns The manifest panel element
+ * @sideEffects none
+ */
 export function ManifestPanel({ version }: { version: ServiceVersion }): ReactElement {
   const m = version.manifest
   return (

--- a/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/OpenApiPanel.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/OpenApiPanel.tsx
@@ -4,12 +4,38 @@ import { useServiceOpenApi } from '../../application/useServiceOpenApi.applicati
 import { OpenApiDocSchema, OpenApiOperationSchema } from '../../domain/schema'
 import s from './ServiceDetailPage.module.css'
 
+/**
+ * Inferred TypeScript type of a decoded OpenAPI operation.
+ */
 type OpenApiOperation = Schema.Schema.Type<typeof OpenApiOperationSchema>
 
+/**
+ * OpenAPI route enriched with its HTTP method and path.
+ */
 type OpenApiRoute = OpenApiOperation & { method: string; path: string }
 
+/**
+ * Type guard that narrows an unknown operation value to {@link OpenApiOperation}.
+ *
+ * @param value - Value to inspect
+ * @returns `true` when the value matches {@link OpenApiOperationSchema}
+ * @sideEffects none
+ */
 const isOpenApiOperation = Schema.is(OpenApiOperationSchema)
 
+/**
+ * Renders the OpenAPI document exposed by a service version.
+ *
+ * Fetches `/services/{serviceId}/openapi?version={version}`, decodes the
+ * response through {@link OpenApiDocSchema}, and lists the documented routes
+ * in a table. Displays loading, error, and empty states.
+ *
+ * @param serviceId - Identifier of the service that owns the OpenAPI endpoint
+ * @param version   - Service version whose OpenAPI document to display
+ * @returns The OpenAPI panel element
+ * @sideEffects Calls {@link useServiceOpenApi} (TanStack Query subscription)
+ *              and decodes the document with Effect Schema on render.
+ */
 export function OpenApiPanel({ serviceId, version }: { serviceId: string; version: string }): React.ReactElement {
   const { data, isLoading, isError, error } = useServiceOpenApi(serviceId, version)
 

--- a/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/ServiceDetailPage.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/ServiceDetailPage.tsx
@@ -9,14 +9,28 @@ import type { InstanceStatus } from '../../domain/types'
 import { VersionCard } from './VersionCard'
 import s from './ServiceDetailPage.module.css'
 
-const STATUS_VARIANT: Record<InstanceStatus, 'success' | 'warning' | 'error'> = {
+/**
+ * Maps an {@link InstanceStatus} to the visual Badge variant used across
+ * the service detail page.
+ *
+ * @sideEffects none
+ */
+export const STATUS_VARIANT: Record<InstanceStatus, 'success' | 'warning' | 'error'> = {
   passing:  'success',
   warning:  'warning',
   critical: 'error',
 }
 
-export { STATUS_VARIANT }
-
+/**
+ * Detail page for a single service.
+ *
+ * Displays an overview tab with version cards and a routing-rules tab that
+ * embeds the {@link RoutingRulesPage} for the service.
+ *
+ * @param serviceId - Identifier of the service to display
+ * @returns The service detail page element
+ * @sideEffects Calls {@link useServiceDetail} (TanStack Query subscription).
+ */
 export function ServiceDetailPage({ serviceId }: { serviceId: string }): ReactElement {
   const { data, isLoading, isError } = useServiceDetail(serviceId)
 

--- a/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/SharedComponents.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/ui/ServiceDetailPage/SharedComponents.tsx
@@ -2,7 +2,26 @@ import { ReactElement } from 'react'
 import type { ReactNode } from 'react'
 import s from './ServiceDetailPage.module.css'
 
-export function SpecCard({ title, children }: { title: string; children: ReactNode }): ReactElement {
+/**
+ * Props for {@link SpecCard}.
+ */
+interface SpecCardProps {
+  /** Card heading. */
+  title: string
+
+  /** Body content, usually a list of {@link KV} rows. */
+  children: ReactNode
+}
+
+/**
+ * Small card for a single section of the manifest specification grid.
+ *
+ * @param title    - Card heading
+ * @param children - Body content
+ * @returns The spec card element
+ * @sideEffects none
+ */
+export function SpecCard({ title, children }: SpecCardProps): ReactElement {
   return (
     <div className={s.specCard}>
       <div className={s.specCardTitle}>{title}</div>
@@ -11,7 +30,26 @@ export function SpecCard({ title, children }: { title: string; children: ReactNo
   )
 }
 
-export function KV({ k, v }: { k: string; v: string }): ReactElement {
+/**
+ * Props for {@link KV}.
+ */
+interface KVProps {
+  /** Key label. */
+  k: string
+
+  /** Value text. */
+  v: string
+}
+
+/**
+ * Single key/value row used inside {@link SpecCard}.
+ *
+ * @param k - Key label
+ * @param v - Value text
+ * @returns The key/value element
+ * @sideEffects none
+ */
+export function KV({ k, v }: KVProps): ReactElement {
   return (
     <div className={s.kv}>
       <span className={s.kvKey}>{k}</span>

--- a/service-mesh/frontend/service-mesh/src/features/services/ui/ServicesPage/ServicesPage.tsx
+++ b/service-mesh/frontend/service-mesh/src/features/services/ui/ServicesPage/ServicesPage.tsx
@@ -6,6 +6,16 @@ import { ServicesTable } from '@/features/registry'
 import { useServices } from '../../application/useServices.application'
 import s from './ServicesPage.module.css'
 
+/**
+ * Page listing all registered services in the mesh.
+ *
+ * Shows a skeleton table while loading, an error card on failure, and a
+ * clickable table that navigates to the selected service's detail page.
+ *
+ * @returns The services page element
+ * @sideEffects Calls {@link useServices} (TanStack Query subscription) and
+ *              {@link useNavigate} (router navigation on row click).
+ */
 export function ServicesPage(): ReactElement {
   const navigate = useNavigate()
   const { data, isLoading, isError } = useServices()

--- a/service-mesh/frontend/service-mesh/src/lib/http.ts
+++ b/service-mesh/frontend/service-mesh/src/lib/http.ts
@@ -2,13 +2,34 @@ import { Effect, Schema } from 'effect'
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
+/**
+ * Base URL for the control-plane REST API.
+ *
+ * Resolved from `import.meta.env.VITE_API_URL` at runtime; falls back to
+ * `http://localhost:4000` when the environment variable is absent.
+ *
+ * @sideEffects Reads `import.meta.env` at module evaluation.
+ */
 export const BASE: string =
   (import.meta.env.VITE_API_URL as string | undefined) ?? 'http://localhost:4000'
 
+/**
+ * Prefixes a relative API path with the versioned REST root.
+ *
+ * @param path - Relative path (e.g. `/services`)
+ * @returns Absolute path including `/api/v1` prefix
+ * @sideEffects none
+ */
 export const endpoint = (path: string): string => `/api/v1${path}`
 
 // ── Typed error ─────────────────────────────────────────────────────────────────
 
+/**
+ * Structured error representing an HTTP or decode failure.
+ *
+ * Carries enough context (status, statusText, path) for the UI layer to
+ * decide on retries, user-visible messages, and logging.
+ */
 export type ApiError = {
   readonly _tag:       'ApiError'
   readonly status:     number
@@ -17,6 +38,15 @@ export type ApiError = {
   readonly message:    string
 }
 
+/**
+ * Factory for {@link ApiError} values.
+ *
+ * @param status     - HTTP status code (0 for network-level failures)
+ * @param statusText - HTTP status text or exception message
+ * @param path       - Request path that produced the error
+ * @returns A branded {@link ApiError} record
+ * @sideEffects none
+ */
 export const makeApiError = (
   status: number,
   statusText: string,
@@ -29,25 +59,45 @@ export const makeApiError = (
   message: `${status} ${statusText}: ${path}`,
 })
 
+/**
+ * Type guard that narrows an unknown value to {@link ApiError}.
+ *
+ * @param e - Value to inspect
+ * @returns `true` when `e` is an object whose `_tag` equals `'ApiError'`
+ * @sideEffects none
+ */
 export const isApiError = (e: unknown): e is ApiError =>
   typeof e === 'object' && e !== null && (e as ApiError)._tag === 'ApiError'
 
 // ── Effect-based fetch (primary) ─────────────────────────────────────────────
-//
-// Returns Effect<T, ApiError, never>.
-// Compose with Effect.retry, Effect.timeout, Effect.catchTag, etc.
-//
-// Example:
-//   apiFetchEffect<Service[]>(endpoint('/services')).pipe(
-//     Effect.retry({ times: 3 }),
-//     Effect.timeout('5 seconds'),
-//   )
-//
-// Pipeline:
-//   1. tryPromise catches network-level throws (DNS, CORS, etc.) → ApiError
-//   2. flatMap inspects HTTP status → Effect.fail for non-ok, Effect.succeed for ok
-//   3. flatMap parses JSON → typed T
 
+/**
+ * Performs a typed HTTP fetch wrapped in an `Effect` pipeline.
+ *
+ * The pipeline:
+ *   1. Wraps `fetch` in `Effect.tryPromise` to catch network errors.
+ *   2. Fails with {@link ApiError} for non-2xx HTTP statuses.
+ *   3. Parses JSON and decodes it through the supplied Effect `Schema`.
+ *
+ * Because the result is an `Effect`, callers can compose retries, timeouts,
+ * and error recovery without leaving the Effect runtime.
+ *
+ * @template T - Decoded response type
+ * @template I - Intermediate JSON type (defaults to `unknown`)
+ * @param path   - Full request path (usually produced by {@link endpoint})
+ * @param schema - Effect schema used to validate and decode the response body
+ * @param init   - Optional `RequestInit` (method, headers, body, etc.)
+ * @returns `Effect<T, ApiError>` representing the decoded response
+ * @sideEffects Performs one HTTP request when executed by the Effect runtime.
+ *
+ * @example
+ * ```ts
+ * apiFetchEffect<Service[]>(endpoint('/services'), ServiceViewSchema).pipe(
+ *   Effect.retry({ times: 3 }),
+ *   Effect.timeout('5 seconds'),
+ * )
+ * ```
+ */
 export const apiFetchEffect = <T, I = unknown>(
   path: string,
   schema: Schema.Schema<T, I>,
@@ -73,15 +123,32 @@ export const apiFetchEffect = <T, I = unknown>(
     ),
   )
 
-// ── Promise-based fetch (compatibility wrapper) ────────────────────────────
-//
-// Thin wrapper for existing api clients — TanStack Query consumes Promise.
-// Migrate call sites to apiFetchEffect incrementally when retry / timeout
-// or structured error handling is needed per-query.
-
+/**
+ * Promise wrapper around {@link apiFetchEffect} for compatibility with
+ * TanStack Query and other Promise-based consumers.
+ *
+ * @template T - Decoded response type
+ * @template I - Intermediate JSON type
+ * @param path   - Full request path
+ * @param schema - Effect schema for response decoding
+ * @param init   - Optional `RequestInit`
+ * @returns Promise that resolves to `T` or rejects with {@link ApiError}
+ * @sideEffects Runs the Effect runtime and performs one HTTP request.
+ */
 export const apiFetch = <T, I = unknown>(path: string, schema: Schema.Schema<T, I>, init?: RequestInit): Promise<T> =>
   Effect.runPromise(apiFetchEffect<T, I>(path, schema, init))
 
+/**
+ * Effect-based fetch for void endpoints (e.g. `DELETE`).
+ *
+ * Identical to {@link apiFetchEffect} except it expects an empty response body
+ * and succeeds with `void` for 2xx statuses.
+ *
+ * @param path - Full request path
+ * @param init - Optional `RequestInit`
+ * @returns `Effect<void, ApiError>`
+ * @sideEffects Performs one HTTP request when executed.
+ */
 export const apiFetchVoidEffect = (
   path: string,
   init?: RequestInit,
@@ -97,5 +164,13 @@ export const apiFetchVoidEffect = (
     ),
   )
 
+/**
+ * Promise wrapper around {@link apiFetchVoidEffect}.
+ *
+ * @param path - Full request path
+ * @param init - Optional `RequestInit`
+ * @returns Promise that resolves to `void` or rejects with {@link ApiError}
+ * @sideEffects Runs the Effect runtime and performs one HTTP request.
+ */
 export const apiFetchVoid = (path: string, init?: RequestInit): Promise<void> =>
   Effect.runPromise(apiFetchVoidEffect(path, init))

--- a/service-mesh/frontend/service-mesh/src/lib/persister.ts
+++ b/service-mesh/frontend/service-mesh/src/lib/persister.ts
@@ -12,12 +12,35 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { get, set, del } from 'idb-keyval'
 import type { Persister } from '@tanstack/react-query-persist-client'
 
+/**
+ * Versioned cache key used for TanStack Query persistence.
+ *
+ * Bumping this value invalidates previously persisted caches after
+ * breaking schema or storage backend changes.
+ *
+ * @sideEffects none
+ */
 const CACHE_KEY = 'sm-query-cache-v2'
 
+/**
+ * Whether the IndexedDB-backed persister is enabled.
+ *
+ * Controlled by `import.meta.env.VITE_IDB_PERSIST`. Defaults to `true`
+ * unless explicitly set to `'false'`.
+ *
+ * @sideEffects Reads `import.meta.env` at module evaluation.
+ */
 const useIdb: boolean =
   (import.meta.env.VITE_IDB_PERSIST as string | undefined) !== 'false'
 
-// IDB-backed async persister — no size limit, non-blocking
+/**
+ * IDB-backed async persister.
+ *
+ * Uses `idb-keyval` for storage, removing the ~5 MB limit imposed by
+ * `localStorage`. Suitable for large query caches and non-blocking writes.
+ *
+ * @sideEffects Reads from / writes to IndexedDB when the persister runs.
+ */
 const idbPersister: Persister = createAsyncStoragePersister({
   storage: {
     getItem:    (key) => get<string>(key),
@@ -27,11 +50,49 @@ const idbPersister: Persister = createAsyncStoragePersister({
   key: CACHE_KEY,
 })
 
-// localStorage fallback — synchronous, ~5 MB cap
+/**
+ * localStorage fallback persister.
+ *
+ * Synchronous and capped at roughly 5 MB. Only instantiated when IDB is
+ * disabled or when `window` is unavailable.
+ *
+ * @sideEffects Reads from / writes to `window.localStorage` when executed.
+ */
 const localStoragePersister: Persister = createSyncStoragePersister({
-  storage: window.localStorage,
+  storage: typeof window !== 'undefined' ? window.localStorage : noopStorage(),
   key: CACHE_KEY,
 })
 
+/**
+ * Active persister exported for `persistQueryClient`.
+ *
+ * Chooses {@link idbPersister} by default and falls back to
+ * {@link localStoragePersister} when `VITE_IDB_PERSIST` is `'false'`.
+ *
+ * @sideEffects none at import time; delegates storage I/O to the chosen persister.
+ */
 export const persister: Persister = useIdb ? idbPersister : localStoragePersister
+
+/**
+ * Re-exported flag so consumers can branch on the active persister kind.
+ *
+ * @sideEffects none
+ */
 export { useIdb as isIdbPersisterEnabled }
+
+/**
+ * Creates a no-op storage object for SSR environments where `window` is absent.
+ *
+ * @returns A `Storage`-like object whose methods resolve immediately and do nothing.
+ * @sideEffects none
+ */
+function noopStorage(): Storage {
+  return {
+    getItem:    () => null,
+    setItem:    () => undefined,
+    removeItem: () => undefined,
+    clear:      () => undefined,
+    key:        () => null,
+    length:     0,
+  }
+}

--- a/service-mesh/frontend/service-mesh/src/lib/queryClient.ts
+++ b/service-mesh/frontend/service-mesh/src/lib/queryClient.ts
@@ -1,7 +1,23 @@
 import { QueryClient } from '@tanstack/react-query'
-import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
 import { persistQueryClient } from '@tanstack/react-query-persist-client'
+import { persister } from './persister'
 
+/**
+ * Shared TanStack Query client for the application.
+ *
+ * Default query options balance freshness with cache stability:
+ * - `staleTime: 30_000` — data is considered fresh for 30 seconds.
+ * - `gcTime: 3_600_000` — inactive cache entries are kept for 1 hour.
+ * - `retry: 2` — transient failures are retried automatically.
+ * - `refetchOnWindowFocus: true` — stale data is refreshed when the window
+ *   regains focus.
+ *
+ * The client is persisted via {@link persister} (IDB by default, with a
+ * localStorage fallback), providing offline-first behaviour.
+ *
+ * @sideEffects Registers a TanStack Query persistence subscription when the
+ *              module is evaluated. Persists cache to IndexedDB/localStorage.
+ */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -13,13 +29,14 @@ export const queryClient = new QueryClient({
   },
 })
 
-// Persist cache in localStorage for local-first behaviour.
-// Can be swapped for an idb-keyval persister for larger payloads.
-const persister = createSyncStoragePersister({
-  storage: window.localStorage,
-  key: 'sm-query-cache',
-})
-
+/**
+ * Starts persisting the {@link queryClient} cache.
+ *
+ * Restores the cache on startup and writes updates to the configured
+ * storage backend. Cached entries older than 24 hours are discarded.
+ *
+ * @sideEffects Reads existing persisted cache and subscribes to cache writes.
+ */
 void persistQueryClient({
   queryClient,
   persister,

--- a/service-mesh/frontend/service-mesh/src/routes/__root.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/__root.tsx
@@ -6,14 +6,32 @@ import { TooltipProvider } from '@/shared/ui'
 import s from './__root.module.css'
 import { ReactElement } from 'react'
 
+/**
+ * Router context provided to every route in the application.
+ *
+ * Carries the shared TanStack Query client so loaders and components can
+ * access cached server state consistently.
+ */
 type RouterContext = {
   queryClient: QueryClient
 }
 
+/**
+ * Root route that wraps every page with the application shell.
+ *
+ * Provides the tooltip provider, sidebar layout, toast container, and the
+ * outlet where matched routes render.
+ */
 export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootLayout,
 })
 
+/**
+ * Root layout component.
+ *
+ * @returns The root application layout element
+ * @sideEffects Mounts the Sonner toast container and Radix Tooltip provider.
+ */
 function RootLayout(): ReactElement {
   return (
     <TooltipProvider>

--- a/service-mesh/frontend/service-mesh/src/routes/index.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/index.tsx
@@ -1,4 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RegistryDashboard } from '@/features/registry'
 
+/**
+ * Root route `/` that renders the registry dashboard.
+ */
 export const Route = createFileRoute('/')({ component: RegistryDashboard })

--- a/service-mesh/frontend/service-mesh/src/routes/nodes.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/nodes.tsx
@@ -4,8 +4,19 @@ import { Card } from '@/shared/ui'
 import s from './placeholder.module.css'
 import {ReactElement} from "react";
 
+/**
+ * Route definition for `/nodes`.
+ *
+ * Displays a placeholder for the upcoming data-plane nodes page.
+ */
 export const Route = createFileRoute('/nodes')({ component: NodesPage })
 
+/**
+ * Placeholder page for data-plane nodes.
+ *
+ * @returns The nodes page element
+ * @sideEffects none
+ */
 export function NodesPage(): ReactElement {
   return (
     <>

--- a/service-mesh/frontend/service-mesh/src/routes/policies.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/policies.tsx
@@ -4,8 +4,19 @@ import { Card } from '@/shared/ui'
 import s from './placeholder.module.css'
 import {ReactElement} from "react";
 
+/**
+ * Route definition for `/policies`.
+ *
+ * Displays a placeholder for the upcoming policies page.
+ */
 export const Route = createFileRoute('/policies')({ component: PoliciesPage })
 
+/**
+ * Placeholder page for retry, timeout, and access policies.
+ *
+ * @returns The policies page element
+ * @sideEffects none
+ */
 export function PoliciesPage(): ReactElement {
   return (
     <>

--- a/service-mesh/frontend/service-mesh/src/routes/revisions.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/revisions.tsx
@@ -4,8 +4,19 @@ import { Card } from '@/shared/ui'
 import s from './placeholder.module.css'
 import {ReactElement} from "react";
 
+/**
+ * Route definition for `/revisions`.
+ *
+ * Displays a placeholder for the upcoming config revision history page.
+ */
 export const Route = createFileRoute('/revisions')({ component: RevisionsPage })
 
+/**
+ * Placeholder page for configuration revision history.
+ *
+ * @returns The revisions page element
+ * @sideEffects none
+ */
 export function RevisionsPage(): ReactElement {
   return (
     <>

--- a/service-mesh/frontend/service-mesh/src/routes/services.$serviceId.routing-rules.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/services.$serviceId.routing-rules.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RoutingRulesPage } from '@/features/routing-rules'
 
+/**
+ * Route definition for `/services/$serviceId/routing-rules`.
+ *
+ * Renders the routing rules management page for the selected service.
+ */
 export const Route = createFileRoute('/services/$serviceId/routing-rules')({
   component: function RoutingRulesRoute() {
     const { serviceId } = Route.useParams()

--- a/service-mesh/frontend/service-mesh/src/routes/services.$serviceId.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/services.$serviceId.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ServiceDetailPage } from '@/features/services'
 
+/**
+ * Route definition for `/services/$serviceId`.
+ *
+ * Renders the detail page for the selected service.
+ */
 export const Route = createFileRoute('/services/$serviceId')({
   component: function ServiceDetailRoute() {
     const { serviceId } = Route.useParams()

--- a/service-mesh/frontend/service-mesh/src/routes/services.index.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/services.index.tsx
@@ -1,4 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ServicesPage } from '@/features/services'
 
+/**
+ * Index route for `/services/` that renders the services list page.
+ */
 export const Route = createFileRoute('/services/')({ component: ServicesPage })

--- a/service-mesh/frontend/service-mesh/src/routes/services.tsx
+++ b/service-mesh/frontend/service-mesh/src/routes/services.tsx
@@ -1,5 +1,11 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
+/**
+ * Layout route for `/services`.
+ *
+ * Renders the matched child route (services index or service detail) inside
+ * an outlet without adding any wrapper UI.
+ */
 export const Route = createFileRoute('/services')({
   component: () => <Outlet />,
 })

--- a/service-mesh/frontend/service-mesh/src/shared/form/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/form/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel export for shared form utilities.
+ *
+ * Prefer importing from `@/shared/form` over deep paths.
+ */
+export { schemaValidator } from './schemaResolver'
+export type { SchemaValidationError } from './schemaResolver'

--- a/service-mesh/frontend/service-mesh/src/shared/form/schemaResolver.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/form/schemaResolver.ts
@@ -21,7 +21,9 @@ export type SchemaValidationError = {
  * a sync validator returning errors) and Effect's Schema (which is the
  * source of truth for shape + invariants).
  *
- * Example:
+ * @returns A validator function `(value: unknown) => SchemaValidationError[]`
+ *
+ * @example
  *   ```ts
  *   const validate = schemaValidator(RoutingRuleSchema)
  *   const errs = validate(formValues) // [] or [{ field, message }, ...]

--- a/service-mesh/frontend/service-mesh/src/shared/table/DataTable.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/table/DataTable.tsx
@@ -8,12 +8,35 @@ import {
 import type {ReactElement} from 'react'
 import s from './DataTable.module.css'
 
+/**
+ * Props for {@link DataTable}.
+ *
+ * @template TData - Row data type, must extend TanStack Table's `RowData`
+ */
 type DataTableProps<TData extends RowData> = {
-    columns: ColumnDef<TData>[]
-    data: TData[]
-    onRowClick?: (row: TData) => void
+  /** Column definitions. */
+  columns: ColumnDef<TData>[]
+
+  /** Data rows to render. */
+  data: TData[]
+
+  /** Optional click handler invoked with the original row data. */
+  onRowClick?: (row: TData) => void
 }
 
+/**
+ * Reusable table built on `@tanstack/react-table`.
+ *
+ * Renders a simple table with headers and body rows. When `onRowClick` is
+ * provided, rows receive a clickable style and cursor.
+ *
+ * @template TData - Row data type
+ * @param columns     - Column definitions
+ * @param data        - Row data
+ * @param onRowClick  - Optional row click handler
+ * @returns The table element
+ * @sideEffects none
+ */
 export const DataTable = <TData extends RowData>({
                                                      data,
                                                      columns,

--- a/service-mesh/frontend/service-mesh/src/shared/table/README.md
+++ b/service-mesh/frontend/service-mesh/src/shared/table/README.md
@@ -1,7 +1,22 @@
-# shared/table
+# `shared/table`
 
-Reserved for the data-table layer. Will host:
+Reusable data table built on `@tanstack/react-table`.
 
-- `DataTable.tsx` — thin wrapper over TanStack Table that keeps existing CSS Modules
+## Exports
 
-Populated in PR 4 (see `docs/ui-refresh-plan.md`).
+- `DataTable<TData>` — generic table with column definitions, header rows, body rows, and optional row click handling.
+
+## Usage
+
+```tsx
+import { DataTable } from '@/shared/table/DataTable'
+import { createColumnHelper } from '@tanstack/react-table'
+
+const col = createColumnHelper<MyRow>()
+const columns = [
+  col.accessor('name', { header: 'Name' }),
+  col.display({ id: 'actions', header: '', cell: ({ row }) => <button>Edit</button> }),
+]
+
+<DataTable data={rows} columns={columns} onRowClick={(row) => console.log(row)} />
+```

--- a/service-mesh/frontend/service-mesh/src/shared/table/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/table/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Barrel export for the shared data table primitive.
+ *
+ * Prefer importing from `@/shared/table` over deep paths.
+ */
+export { DataTable } from './DataTable'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/AlertDialog/AlertDialog.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/AlertDialog/AlertDialog.tsx
@@ -31,12 +31,29 @@ import s from './AlertDialog.module.css'
  *   </AlertDialog>
  */
 
+/**
+ * Props for {@link AlertDialog}.
+ */
 export type AlertDialogProps = {
+  /** Whether the dialog is currently open. */
   open:           boolean
+
+  /** Called when the dialog requests to open or close. */
   onOpenChange:   (open: boolean) => void
+
+  /** Dialog content, usually {@link AlertDialogContent}. */
   children:       ReactNode
 }
 
+/**
+ * Root component that controls alert dialog visibility.
+ *
+ * @param open         - Current open state
+ * @param onOpenChange - Open state change handler
+ * @param children     - Dialog content
+ * @returns The alert dialog root element
+ * @sideEffects none
+ */
 export function AlertDialog({ open, onOpenChange, children }: AlertDialogProps): ReactElement {
   return (
     <RadixAlertDialog.Root open={open} onOpenChange={onOpenChange}>
@@ -45,9 +62,18 @@ export function AlertDialog({ open, onOpenChange, children }: AlertDialogProps):
   )
 }
 
+/**
+ * Modal container with overlay and focus trap.
+ *
+ * `aria-labelledby` and `aria-describedby` are wired automatically by Radix
+ * when {@link AlertDialogTitle} and {@link AlertDialogDescription} are rendered
+ * inside.
+ *
+ * @param children - Dialog body content
+ * @returns The alert dialog content element
+ * @sideEffects Mounts a Radix portal and focus trap.
+ */
 export function AlertDialogContent({ children }: { children: ReactNode }): ReactElement {
-  // aria-labelledby and aria-describedby are wired automatically by Radix
-  // when <AlertDialogTitle>/<AlertDialogDescription> are rendered inside.
   return (
     <RadixAlertDialog.Portal>
       <RadixAlertDialog.Overlay className={s.overlay}>
@@ -59,17 +85,39 @@ export function AlertDialogContent({ children }: { children: ReactNode }): React
   )
 }
 
+/**
+ * Visual variant for the optional header icon.
+ */
 type IconVariant = 'danger'
 
+/**
+ * Props for {@link AlertDialogHeader}.
+ */
+type AlertDialogHeaderProps = {
+  /** Header content, typically {@link AlertDialogTitle}. */
+  children:      ReactNode
+
+  /** Optional icon rendered above the title. */
+  icon?:         ReactNode
+
+  /** Visual variant applied to the icon wrapper. */
+  iconVariant?:  IconVariant
+}
+
+/**
+ * Header section of an alert dialog, optionally decorated with an icon.
+ *
+ * @param children     - Header content
+ * @param icon         - Optional icon element
+ * @param iconVariant  - Optional icon variant
+ * @returns The alert dialog header element
+ * @sideEffects none
+ */
 export function AlertDialogHeader({
   children,
   icon,
   iconVariant,
-}: {
-  children:      ReactNode
-  icon?:         ReactNode
-  iconVariant?:  IconVariant
-}): ReactElement {
+}: AlertDialogHeaderProps): ReactElement {
   return (
     <div className={s.header}>
       {icon ? (
@@ -82,24 +130,48 @@ export function AlertDialogHeader({
   )
 }
 
+/**
+ * Accessible title rendered as an `<h2>`.
+ *
+ * Radix auto-generates an id and wires it as `aria-labelledby` on the dialog
+ * content.
+ *
+ * @param children - Title text
+ * @returns The alert dialog title element
+ * @sideEffects none
+ */
 export function AlertDialogTitle({ children }: { children: ReactNode }): ReactElement {
-  // Radix' Title renders an <h2> with an auto-generated id and wires it up
-  // as aria-labelledby on Content.
   return <RadixAlertDialog.Title className={s.title}>{children}</RadixAlertDialog.Title>
 }
 
+/**
+ * Accessible description rendered as a `<p>`.
+ *
+ * Radix auto-generates an id and wires it as `aria-describedby` on the dialog
+ * content.
+ *
+ * @param children - Description text
+ * @returns The alert dialog description element
+ * @sideEffects none
+ */
 export function AlertDialogDescription({ children }: { children: ReactNode }): ReactElement {
-  // Radix' Description renders a <p> with an auto-generated id and wires it
-  // up as aria-describedby on Content.
   return <RadixAlertDialog.Description className={s.description}>{children}</RadixAlertDialog.Description>
 }
 
+/**
+ * Footer action row, typically containing {@link AlertDialogCancel} and
+ * {@link AlertDialogAction}.
+ *
+ * @param children - Action buttons
+ * @returns The alert dialog actions element
+ * @sideEffects none
+ */
 export function AlertDialogActions({ children }: { children: ReactNode }): ReactElement {
   return <div className={s.actions}>{children}</div>
 }
 
 /**
- * Wrap your existing <Button> with `asChild` to inherit visuals while letting
+ * Wrap your existing `<Button>` with `asChild` to inherit visuals while letting
  * Radix manage focus and keyboard. Cancel closes the dialog automatically.
  */
 export const AlertDialogCancel = RadixAlertDialog.Cancel

--- a/service-mesh/frontend/service-mesh/src/shared/ui/AlertDialog/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/AlertDialog/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel export for the {@link AlertDialog} primitive and its compound components.
+ *
+ * Import from `@/shared/ui` instead of deep paths.
+ */
 export {
   AlertDialog,
   AlertDialogContent,

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Badge/Badge.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Badge/Badge.tsx
@@ -1,13 +1,33 @@
 import type {ReactElement, ReactNode} from 'react'
 import s from './Badge.module.css'
 
+/**
+ * Visual variant of the {@link Badge} primitive.
+ */
 type BadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral'
 
+/**
+ * Props for {@link Badge}.
+ */
 type BadgeProps = {
+  /** Visual style variant. */
   variant?: BadgeVariant
+
+  /** Badge text. */
   children: ReactNode
 }
 
+/**
+ * Small status badge with a coloured dot and text.
+ *
+ * Used to display instance statuses, labels, and other compact state
+ * indicators.
+ *
+ * @param variant  - Visual variant (defaults to `neutral`)
+ * @param children - Badge text
+ * @returns The badge element
+ * @sideEffects none
+ */
 export function Badge({ variant = 'neutral', children }: BadgeProps): ReactElement {
   return (
     <span className={s.badge} data-variant={variant}>

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Badge/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Badge/index.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel export for the {@link Badge} primitive.
+ */
 export { Badge } from './Badge'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Button/Button.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Button/Button.tsx
@@ -1,13 +1,32 @@
 import type {ButtonHTMLAttributes, ReactElement, ReactNode} from 'react'
 import s from './Button.module.css'
 
+/**
+ * Visual variant of the {@link Button} primitive.
+ */
 type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
 
+/**
+ * Props for {@link Button}.
+ */
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Visual style variant. */
   variant?: ButtonVariant
+
+  /** Button content. */
   children: ReactNode
 }
 
+/**
+ * Button primitive styled with CSS Modules and driven by a `data-variant`
+ * attribute for easy theming.
+ *
+ * @param variant  - Visual variant (defaults to `secondary`)
+ * @param children - Button label or icon
+ * @param props    - Standard `<button>` attributes forwarded as-is
+ * @returns The button element
+ * @sideEffects none
+ */
 export function Button({ variant = 'secondary', children, ...props }: ButtonProps): ReactElement {
   return (
     <button

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Button/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Button/index.ts
@@ -1,1 +1,7 @@
+/**
+ * Barrel export for the {@link Button} primitive.
+ *
+ * Import from `@/shared/ui` instead of deep paths to keep consumers decoupled
+ * from the internal file layout.
+ */
 export { Button } from './Button'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Card/Card.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Card/Card.tsx
@@ -2,12 +2,29 @@ import {type ReactNode, type CSSProperties, ReactElement} from 'react'
 import clsx from 'clsx'
 import s from './Card.module.css'
 
+/**
+ * Props for {@link Card}.
+ */
 type CardProps = {
+  /** Card body content. */
   children: ReactNode
+
+  /** Optional inline styles. */
   style?: CSSProperties
+
+  /** Additional CSS class names. */
   className?: string
 }
 
+/**
+ * Generic card container with a subtle border and background.
+ *
+ * @param children  - Body content
+ * @param style     - Optional inline styles
+ * @param className - Optional extra classes
+ * @returns The card element
+ * @sideEffects none
+ */
 export function Card({ children, style, className }: CardProps): ReactElement {
   return (
     <div className={clsx(s.card, className)} style={style}>
@@ -16,14 +33,36 @@ export function Card({ children, style, className }: CardProps): ReactElement {
   )
 }
 
+/**
+ * Header row inside a {@link Card}, usually containing a title and an icon.
+ *
+ * @param children - Header content
+ * @returns The card header element
+ * @sideEffects none
+ */
 export function CardHeader({ children }: { children: ReactNode }): ReactElement {
   return <div className={s.header}>{children}</div>
 }
 
+/**
+ * Title element inside a {@link CardHeader}.
+ *
+ * @param children - Title text
+ * @returns The card title element
+ * @sideEffects none
+ */
 export function CardTitle({ children }: { children: ReactNode }): ReactElement {
   return <h3 className={s.title}>{children}</h3>
 }
 
+/**
+ * Large numeric or emphasised value displayed inside a {@link Card}.
+ *
+ * @param children - Value content
+ * @param style    - Optional inline styles
+ * @returns The card value element
+ * @sideEffects none
+ */
 export function CardValue({ children, style }: { children: ReactNode; style?: CSSProperties }): ReactElement {
   return <p className={s.value} style={style}>{children}</p>
 }

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Card/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Card/index.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel export for the {@link Card} primitive and its layout helpers.
+ */
 export { Card, CardHeader, CardTitle, CardValue } from './Card'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Dialog/Dialog.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Dialog/Dialog.tsx
@@ -31,12 +31,29 @@ import s from './Dialog.module.css'
  * presses Escape. Use it to wire dirty-checks at the call site.
  */
 
+/**
+ * Props for {@link Dialog}.
+ */
 export type DialogProps = {
+  /** Whether the dialog is currently open. */
   open:                 boolean
+
+  /** Called when the dialog requests to open or close. */
   onOpenChange:         (open: boolean) => void
+
+  /** Dialog content, usually {@link DialogContent}. */
   children:             ReactNode
 }
 
+/**
+ * Root component that controls dialog visibility.
+ *
+ * @param open         - Current open state
+ * @param onOpenChange - Open state change handler
+ * @param children     - Dialog content
+ * @returns The dialog root element
+ * @sideEffects none
+ */
 export function Dialog({ open, onOpenChange, children }: DialogProps): ReactElement {
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange}>
@@ -45,26 +62,48 @@ export function Dialog({ open, onOpenChange, children }: DialogProps): ReactElem
   )
 }
 
+/**
+ * Props for {@link DialogContent}.
+ */
 export type DialogContentProps = {
+  /** Modal width preset. */
   size?:        'md' | 'sm'
+
   /**
    * Called when the user attempts to close the dialog via overlay click or
    * Escape. Calling `event.preventDefault()` keeps it open. Use this when you
    * need a dirty-check confirmation.
    */
   onInteractOutside?:   RadixDialog.DialogContentProps['onInteractOutside']
+
+  /**
+   * Called when the user presses Escape.
+   */
   onEscapeKeyDown?:     RadixDialog.DialogContentProps['onEscapeKeyDown']
+
+  /** Dialog body content. */
   children:             ReactNode
+
+  /** Additional CSS class names. */
   className?:           string
 }
 
+/**
+ * Modal container with overlay, focus trap, and optional size.
+ *
+ * @param size              - Width preset
+ * @param onInteractOutside - Overlay-click / outside-interact handler
+ * @param onEscapeKeyDown   - Escape key handler
+ * @param children          - Dialog body content
+ * @param className         - Extra CSS classes
+ * @returns The dialog content element
+ * @sideEffects Mounts a Radix portal and focus trap.
+ */
 export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
   function DialogContent(
     { size = 'md', onInteractOutside, onEscapeKeyDown, children, className },
     ref,
   ) {
-    // aria-labelledby and aria-describedby are wired automatically by Radix
-    // when <DialogTitle>/<DialogDescription> are rendered inside.
     return (
       <RadixDialog.Portal>
         <RadixDialog.Overlay className={s.overlay}>
@@ -82,31 +121,93 @@ export const DialogContent = forwardRef<HTMLDivElement, DialogContentProps>(
   },
 )
 
-export function DialogHeader({ children, withIcon = false }: { children: ReactNode; withIcon?: boolean }): ReactElement {
+/**
+ * Props for {@link DialogHeader}.
+ */
+type DialogHeaderProps = {
+  /** Header content, typically {@link DialogTitle}. */
+  children: ReactNode
+
+  /** When true, adds extra spacing for an icon placed beside the title. */
+  withIcon?: boolean
+}
+
+/**
+ * Header section of a dialog, usually containing the title and close button.
+ *
+ * @param children - Header content
+ * @param withIcon - Whether an icon is present
+ * @returns The dialog header element
+ * @sideEffects none
+ */
+export function DialogHeader({ children, withIcon = false }: DialogHeaderProps): ReactElement {
   return <div className={withIcon ? s.headerWithIcon : s.header}>{children}</div>
 }
 
+/**
+ * Props for {@link DialogTitle}.
+ */
 export type DialogTitleProps = {
+  /** Title text. */
   children:   ReactNode
 }
 
+/**
+ * Accessible title rendered as an `<h2>`.
+ *
+ * Radix auto-generates an id and wires it as `aria-labelledby` on the dialog
+ * content.
+ *
+ * @param children - Title text
+ * @returns The dialog title element
+ * @sideEffects none
+ */
 export function DialogTitle({ children }: DialogTitleProps): ReactElement {
-  // Radix' Title renders an <h2> with an auto-generated id and wires it up
-  // as aria-labelledby on Content. We just style it.
   return <RadixDialog.Title className={s.title}>{children}</RadixDialog.Title>
 }
 
+/**
+ * Props for {@link DialogDescription}.
+ */
 export type DialogDescriptionProps = {
+  /** Description text. */
   children:   ReactNode
 }
 
+/**
+ * Accessible description rendered as a `<p>`.
+ *
+ * Radix auto-generates an id and wires it as `aria-describedby` on the dialog
+ * content.
+ *
+ * @param children - Description text
+ * @returns The dialog description element
+ * @sideEffects none
+ */
 export function DialogDescription({ children }: DialogDescriptionProps): ReactElement {
-  // Radix' Description renders a <p> with an auto-generated id and wires it
-  // up as aria-describedby on Content.
   return <RadixDialog.Description className={s.description}>{children}</RadixDialog.Description>
 }
 
-export function DialogActions({ children, compact = false }: { children: ReactNode; compact?: boolean }): ReactElement {
+/**
+ * Props for {@link DialogActions}.
+ */
+type DialogActionsProps = {
+  /** Action buttons. */
+  children: ReactNode
+
+  /** Use a compact layout with reduced spacing. */
+  compact?: boolean
+}
+
+/**
+ * Footer action row, typically containing cancel and confirm buttons.
+ *
+ * @param children - Action buttons
+ * @param compact  - Whether to use compact spacing
+ * @returns The dialog actions element
+ * @sideEffects none
+ */
+export function DialogActions({ children, compact = false }: DialogActionsProps): ReactElement {
   return <div className={compact ? s.actionsCompact : s.actions}>{children}</div>
 }
 
@@ -117,6 +218,10 @@ export function DialogActions({ children, compact = false }: { children: ReactNo
  *
  * For a textual cancel button inside `<DialogActions>`, just call
  * `onOpenChange(false)` (or your dirty-checked closer) from the `Button`.
+ *
+ * @param label - Accessible label for the close button (defaults to "Close")
+ * @returns The close icon button element
+ * @sideEffects Triggers Radix dialog close on click.
  */
 export function DialogCloseIconButton({ label = 'Close' }: { label?: string }): ReactElement {
   return (

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Dialog/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Dialog/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel export for the {@link Dialog} primitive and its compound components.
+ *
+ * Import from `@/shared/ui` instead of deep paths.
+ */
 export {
   Dialog,
   DialogContent,

--- a/service-mesh/frontend/service-mesh/src/shared/ui/ErrorCard/ErrorCard.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/ErrorCard/ErrorCard.tsx
@@ -3,13 +3,33 @@ import { Card } from '../Card'
 import { Button } from '../Button'
 import s from './ErrorCard.module.css'
 
+/**
+ * Props for {@link ErrorCard}.
+ */
 interface ErrorCardProps {
+  /** Optional card heading. Defaults to "Error". */
   title?: string
+
+  /** Primary error message. */
   message: string
+
+  /** Called when the user presses the Retry button. */
   onRetry?: () => void
+
+  /** Optional extra content rendered below the message. */
   children?: ReactNode
 }
 
+/**
+ * Styled error card with an icon, message, and optional retry action.
+ *
+ * @param title   - Card heading
+ * @param message - Primary error message
+ * @param onRetry - Optional retry callback
+ * @param children - Optional additional content
+ * @returns The error card element
+ * @sideEffects Calls `onRetry` when the retry button is clicked.
+ */
 export function ErrorCard({ title = 'Error', message, onRetry, children }: ErrorCardProps): ReactElement {
   return (
     <Card className={s.errorCard}>

--- a/service-mesh/frontend/service-mesh/src/shared/ui/ErrorCard/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/ErrorCard/index.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel export for the {@link ErrorCard} primitive.
+ */
 export { ErrorCard } from './ErrorCard'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Skeleton/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Skeleton/index.ts
@@ -1,1 +1,4 @@
+/**
+ * Barrel export for the {@link Skeleton} loading placeholder.
+ */
 export { Skeleton } from './Skeleton'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tabs/Tabs.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tabs/Tabs.tsx
@@ -31,17 +31,33 @@ import s from './Tabs.module.css'
  * - "card"                — compact version-level tabs, slightly smaller text.
  */
 
-// ─── Root ──────────────────────────────────────────────────────────────────
-
+/**
+ * Props for {@link Tabs}.
+ */
 export type TabsProps = {
   /** Controlled active tab key. */
   value?: string
+
   /** Default tab for uncontrolled usage. */
   defaultValue?: string
+
+  /** Called when the active tab changes. */
   onValueChange?: (value: string) => void
+
+  /** Tab list and panel children. */
   children: ReactNode
 }
 
+/**
+ * Root tabs component. Supports both controlled and uncontrolled modes.
+ *
+ * @param value         - Controlled active tab key
+ * @param defaultValue  - Default active tab key for uncontrolled usage
+ * @param onValueChange - Active tab change handler
+ * @param children      - Tab list and panels
+ * @returns The tabs root element
+ * @sideEffects none
+ */
 export function Tabs({ value, defaultValue, onValueChange, children }: TabsProps): ReactElement {
   return (
     <RadixTabs.Root value={value} defaultValue={defaultValue} onValueChange={onValueChange}>
@@ -50,14 +66,29 @@ export function Tabs({ value, defaultValue, onValueChange, children }: TabsProps
   )
 }
 
-// ─── List ───────────────────────────────────────────────────────────────────
-
+/**
+ * Props for {@link TabsList}.
+ */
 export type TabsListProps = {
+  /** Visual style variant. */
   variant?: 'underline' | 'card'
+
+  /** Additional CSS class names. */
   className?: string
+
+  /** Tab trigger children. */
   children: ReactNode
 }
 
+/**
+ * Container for tab triggers. Renders the accessible `tablist` role.
+ *
+ * @param variant   - Visual style variant
+ * @param className - Extra CSS classes
+ * @param children  - Tab triggers
+ * @returns The tab list element
+ * @sideEffects none
+ */
 export function TabsList({ variant = 'underline', className, children }: TabsListProps): ReactElement {
   return (
     <RadixTabs.List className={clsx(s.list, variant === 'card' && s.listCard, className)}>
@@ -66,14 +97,29 @@ export function TabsList({ variant = 'underline', className, children }: TabsLis
   )
 }
 
-// ─── Trigger ────────────────────────────────────────────────────────────────
-
+/**
+ * Props for {@link TabsTrigger}.
+ */
 export type TabsTriggerProps = {
+  /** Tab key associated with this trigger. */
   value: string
+
+  /** Additional CSS class names. */
   className?: string
+
+  /** Trigger label. */
   children: ReactNode
 }
 
+/**
+ * Individual tab trigger. Renders an accessible `tab` role.
+ *
+ * @param value     - Tab key
+ * @param className - Extra CSS classes
+ * @param children  - Trigger label
+ * @returns The tab trigger element
+ * @sideEffects none
+ */
 export function TabsTrigger({ value, className, children }: TabsTriggerProps): ReactElement {
   return (
     <RadixTabs.Trigger value={value} className={clsx(s.trigger, className)}>
@@ -82,16 +128,36 @@ export function TabsTrigger({ value, className, children }: TabsTriggerProps): R
   )
 }
 
-// ─── Content ────────────────────────────────────────────────────────────────
-
+/**
+ * Props for {@link TabsContent}.
+ */
 export type TabsContentProps = {
+  /** Tab key that activates this panel. */
   value: string
-  /** Extra padding — default true for "underline" page tabs, pass false for "card" tabs that have their own body padding. */
+
+  /**
+   * Whether to add extra padding. Default is `false`; page-level tabs often
+   * add their own body padding, while card tabs rely on this flag.
+   */
   padded?: boolean
+
+  /** Additional CSS class names. */
   className?: string
+
+  /** Panel content. */
   children: ReactNode
 }
 
+/**
+ * Tab panel rendered when the associated {@link TabsTrigger} is active.
+ *
+ * @param value     - Tab key
+ * @param padded    - Whether to add content padding
+ * @param className - Extra CSS classes
+ * @param children  - Panel content
+ * @returns The tab content element
+ * @sideEffects none
+ */
 export function TabsContent({ value, padded = false, className, children }: TabsContentProps): ReactElement {
   return (
     <RadixTabs.Content

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tabs/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tabs/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Barrel export for the {@link Tabs} primitive and its compound components.
+ *
+ * Import from `@/shared/ui` instead of deep paths.
+ */
 export {
   Tabs,
   TabsList,

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.tsx
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/Tooltip.tsx
@@ -27,18 +27,28 @@ import s from './Tooltip.module.css'
  * avoid an extra <span> in the DOM.
  */
 
-// ─── Provider ───────────────────────────────────────────────────────────────
-// Mount once at root — wraps the whole app so all tooltips share the same
-// delay. Already included in this file for convenience if you want to add it
-// to RootLayout, otherwise each <Tooltip> creates its own provider which is
-// also fine.
-
+/**
+ * Props for {@link TooltipProvider}.
+ */
 export type TooltipProviderProps = {
   /** Delay before tooltip shows on hover (ms). Default 400. */
   delayDuration?: number
+
+  /** Children that may contain {@link Tooltip} components. */
   children: ReactNode
 }
 
+/**
+ * Provider that configures global tooltip delay.
+ *
+ * Mount once near the application root so all tooltips share the same
+ * timing. Nested providers are also supported.
+ *
+ * @param delayDuration - Hover delay in milliseconds
+ * @param children      - Child tree
+ * @returns The tooltip provider element
+ * @sideEffects none
+ */
 export function TooltipProvider({ delayDuration = 400, children }: TooltipProviderProps): ReactElement {
   return (
     <RadixTooltip.Provider delayDuration={delayDuration}>
@@ -47,22 +57,41 @@ export function TooltipProvider({ delayDuration = 400, children }: TooltipProvid
   )
 }
 
-// ─── Tooltip ────────────────────────────────────────────────────────────────
-
+/**
+ * Props for {@link Tooltip}.
+ */
 export type TooltipProps = {
   /** Tooltip text or rich content. */
   content: ReactNode
+
   /** The element that triggers the tooltip. */
   children: ReactNode
+
+  /** Preferred placement relative to the trigger. */
   side?: 'top' | 'bottom' | 'left' | 'right'
+
   /** Offset from the trigger in px. Default 6. */
   sideOffset?: number
+
   /** Override delay for this specific tooltip. */
   delayDuration?: number
+
   /** Disable the tooltip without removing it from the tree. */
   disabled?: boolean
 }
 
+/**
+ * Tooltip that appears on hover or focus of its child trigger.
+ *
+ * @param content       - Tooltip text or rich content
+ * @param children      - Trigger element
+ * @param side          - Preferred placement
+ * @param sideOffset    - Offset from trigger in pixels
+ * @param delayDuration - Optional per-tooltip delay override
+ * @param disabled      - Whether to suppress the tooltip
+ * @returns The tooltip element (or just children when disabled)
+ * @sideEffects Renders a Radix tooltip portal when not disabled.
+ */
 export function Tooltip({
   content,
   children,
@@ -72,15 +101,12 @@ export function Tooltip({
   disabled = false,
 }: TooltipProps): ReactElement {
   if (disabled) {
-    // Render children as-is when tooltip is disabled
     return <>{children}</>
   }
 
   return (
     <RadixTooltip.Root delayDuration={delayDuration}>
       <RadixTooltip.Trigger asChild>
-        {/* asChild passes the ref + event handlers to the child DOM element
-            without wrapping it in an extra element */}
         <span style={{ display: 'contents' }}>{children}</span>
       </RadixTooltip.Trigger>
 

--- a/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/Tooltip/index.ts
@@ -1,2 +1,7 @@
+/**
+ * Barrel export for the {@link Tooltip} primitive and its provider.
+ *
+ * Import from `@/shared/ui` instead of deep paths.
+ */
 export { Tooltip, TooltipProvider } from './Tooltip'
 export type { TooltipProps, TooltipProviderProps } from './Tooltip'

--- a/service-mesh/frontend/service-mesh/src/shared/ui/index.ts
+++ b/service-mesh/frontend/service-mesh/src/shared/ui/index.ts
@@ -1,6 +1,14 @@
 // Public barrel for shared UI primitives.
 // Prefer importing from '@/shared/ui' over deep paths.
 
+/**
+ * Public surface of the shared UI design system.
+ *
+ * All primitives are headless or lightly-styled Radix wrappers plus a few
+ * custom components (Skeleton, ErrorCard). Import from here to stay
+ * decoupled from the internal file layout.
+ */
+
 export { Button } from './Button'
 export { Card, CardHeader, CardTitle, CardValue } from './Card'
 export { Badge } from './Badge'

--- a/service-mesh/frontend/service-mesh/src/store/ui.ts
+++ b/service-mesh/frontend/service-mesh/src/store/ui.ts
@@ -1,13 +1,33 @@
 import { create } from 'zustand'
 
+/**
+ * Pure UI state managed by Zustand.
+ *
+ * This slice intentionally contains no server state; it only tracks
+ * client-only concerns such as sidebar visibility and the currently
+ * selected service identifier.
+ */
 type UIState = {
+  /** Whether the sidebar is currently collapsed. */
   sidebarCollapsed: boolean
+
+  /** Toggles {@link sidebarCollapsed} between `true` and `false`. */
   toggleSidebar: () => void
 
+  /** ID of the service currently selected in the UI, or `null` if none. */
   selectedServiceId: string | null
+
+  /** Sets {@link selectedServiceId}. Pass `null` to clear the selection. */
   setSelectedService: (id: string | null) => void
 }
 
+/**
+ * Zustand store for global UI state.
+ *
+ * @sideEffects Creates a Zustand store singleton at module evaluation.
+ *              Mutations are confined to the store's internal state;
+ *              consumers receive stable references.
+ */
 export const useUIStore = create<UIState>((set) => ({
   sidebarCollapsed: false,
   toggleSidebar: (): void => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),


### PR DESCRIPTION
## What changed

- Added JSDoc to 200+ exports across `lib/`, `features/`, `shared/ui/`, `routes/`, `components/layout/`, `store/`.
- Achieved **100% JSDoc coverage** for production code.
- Configured `eslint-plugin-jsdoc` with TypeScript-aware rules:
  - `require-jsdoc` / `require-description` / `require-returns` as errors
  - parameter/return types delegated to TypeScript (no duplication)
  - custom tags `@sideEffects` and `@invariants` allowed
- Fixed `lib/queryClient.ts` to import `persister` from `./persister` instead of duplicating a localStorage persister.
- Hardened `lib/persister.ts` with `typeof window !== 'undefined'` guard and a `noopStorage()` SSR fallback.
- Added missing barrel exports:
  - `shared/table/index.ts`
  - `shared/form/index.ts`
- Cleaned up path-alias imports containing `.ts` / `.tsx` extensions.
- Updated `frontend/FRONTEND_AUDIT.md` with progress log.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | ✅ Passes |
| `npm test` | ✅ 115/115 passed |
| `npm run lint` | ⚠️ 20 errors, 19 warnings (same as before; no new JSDoc regressions) |

## Scope

frontend/service-mesh/src/ — no runtime logic changes, documentation + lint config + persister fix only.
